### PR TITLE
Fix: Support attach configurations for coreclr debugger

### DIFF
--- a/src/debuggingExecutor.ts
+++ b/src/debuggingExecutor.ts
@@ -34,11 +34,13 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      * Start a debugging session
      */
     public async startDebugging(
-        workingDirectory: string, 
+        workingDirectory: string,
         config: vscode.DebugConfiguration
     ): Promise<boolean> {
         try {
-            if (config.type === 'coreclr') {
+            // Special handling for coreclr launch configurations (not attach)
+            // Attach configurations use processName/processId instead of program
+            if (config.type === 'coreclr' && config.request !== 'attach') {
                 // Open the specific test file instead of the workspace folder
                 const testFileUri = vscode.Uri.file(config.program);
                 await vscode.commands.executeCommand('vscode.open', testFileUri);


### PR DESCRIPTION
## Problem

The `startDebugging` method in `debuggingExecutor.ts` assumes all `coreclr` configurations have a `program` property. However, **attach configurations** use `processName` or `processId` instead of `program`.

This causes the extension to crash with:
```
Cannot read properties of undefined (reading 'replace')
```

When trying to use attach configurations like:
```json
{
    "name": "Attach to Process",
    "type": "coreclr",
    "request": "attach",
    "processName": "MyApp.exe"
}
```

## Solution

Added a check for `config.request !== 'attach'` to skip the special coreclr test handling for attach configurations. This allows attach configurations to correctly use `vscode.debug.startDebugging()`.

## Testing

- Tested with attach configurations for .NET Service Fabric services
- Verified launch configurations still work as expected
- Successfully attached to running processes using `processName` parameter

## Changes

- `src/debuggingExecutor.ts`: Added condition to exclude attach requests from special coreclr handling