### PR TITLE
Add Codex agent configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DebugMCP (MCP Server) - Empowering AI Agents with Multi-Language Debugging Capabilities
 
-Let AI agents debug your code inside VS Code — set breakpoints, step through execution, inspect variables, and evaluate expressions. Works with **GitHub Copilot**, **Cline**, **Cursor**, and any MCP-compatible assistant. Supports **Python**, **JavaScript/TypeScript**, **Java**, **C#**, **C++**, **Go**, **Rust**, **PHP**, and **Ruby**.
+Let AI agents debug your code inside VS Code — set breakpoints, step through execution, inspect variables, and evaluate expressions. Works with **Codex**, **GitHub Copilot**, **Cline**, **Cursor**, and any MCP-compatible assistant. Supports **Python**, **JavaScript/TypeScript**, **Java**, **C#**, **C++**, **Go**, **Rust**, **PHP**, and **Ruby**.
 
 > **📢 Beta Version Notice**: This is a beta version of DebugMCP maintained by [ozzafar@microsoft.com](mailto:ozzafar@microsoft.com) and [orbarila@microsoft.com](mailto:orbarila@microsoft.com). We welcome feedback and contributions to help improve this extension.
 
@@ -173,6 +173,18 @@ Add to Cursor's MCP settings:
     }
   }
 }
+```
+
+#### Codex
+Register DebugMCP with Codex:
+```bash
+codex mcp add debugmcp --url http://localhost:3001/mcp
+```
+
+Or add the equivalent configuration to `~/.codex/config.toml` (`${CODEX_HOME}/config.toml` if `CODEX_HOME` is set):
+```toml
+[mcp_servers.debugmcp]
+url = "http://localhost:3001/mcp"
 ```
 
 ### Extension Settings

--- a/docs/architecture/agentConfigurationManager.md
+++ b/docs/architecture/agentConfigurationManager.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Handles automatic configuration of AI coding agents (Cline, GitHub Copilot, Cursor) to connect to the DebugMCP server. Provides a seamless onboarding experience.
+Handles automatic configuration of AI coding agents (Cline, GitHub Copilot, Cursor, Codex) to connect to the DebugMCP server. Provides a seamless onboarding experience.
 
 ## Motivation
 
@@ -23,6 +23,7 @@ For AI agents to use DebugMCP, they need MCP server configuration in their setti
 | Cline | `cline_mcp_settings.json` | `mcpServers` |
 | GitHub Copilot | `mcp.json` | `servers` |
 | Cursor | `mcp_settings.json` | `mcpServers` |
+| Codex | `~/.codex/config.toml` or `${CODEX_HOME}/config.toml` | `mcp_servers.debugmcp` |
 
 ## Key Concepts
 
@@ -48,6 +49,12 @@ The configuration written to agent settings:
 }
 ```
 
+Codex uses TOML:
+```toml
+[mcp_servers.debugmcp]
+url = "http://localhost:3001/mcp"
+```
+
 ### Popup State
 
 Uses VS Code's `globalState` to track whether the onboarding popup has been shown, preventing repeated prompts on every activation.
@@ -57,6 +64,7 @@ Uses VS Code's `globalState` to track whether the onboarding popup has been show
 - Class definition: `src/utils/agentConfigurationManager.ts`
 - Agent definitions: `getSupportedAgents()`
 - Config writing: `addDebugMCPToAgent()`
+- Codex TOML upsert: `upsertCodexDebugMCPConfig()`
 - Path detection: `getConfigBasePath()`
 - Popup logic: `shouldShowPopup()`, `showAgentSelectionPopup()`
 

--- a/src/test/agentConfigurationManager.test.ts
+++ b/src/test/agentConfigurationManager.test.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import { upsertCodexDebugMCPConfig } from '../utils/agentConfigurationManager';
+
+suite('AgentConfigurationManager Codex TOML configuration', () => {
+    const mcpServerUrl = 'http://localhost:3001/mcp';
+
+    test('upsertCodexDebugMCPConfig should create config from empty content', () => {
+        const result = upsertCodexDebugMCPConfig('', mcpServerUrl);
+
+        assert.strictEqual(result, `[mcp_servers.debugmcp]
+url = "${mcpServerUrl}"
+`);
+    });
+
+    test('upsertCodexDebugMCPConfig should preserve unrelated TOML content', () => {
+        const existingConfig = `model = "gpt-5.4"
+
+[profiles.default]
+sandbox = "workspace-write"
+`;
+
+        const result = upsertCodexDebugMCPConfig(existingConfig, mcpServerUrl);
+
+        assert.strictEqual(result, `${existingConfig}
+[mcp_servers.debugmcp]
+url = "${mcpServerUrl}"
+`);
+    });
+
+    test('upsertCodexDebugMCPConfig should update an existing DebugMCP URL', () => {
+        const existingConfig = `[mcp_servers.debugmcp]
+url = "http://localhost:3002/mcp"
+`;
+
+        const result = upsertCodexDebugMCPConfig(existingConfig, mcpServerUrl);
+
+        assert.strictEqual(result, `[mcp_servers.debugmcp]
+url = "${mcpServerUrl}"
+`);
+    });
+
+    test('upsertCodexDebugMCPConfig should add URL to an existing DebugMCP section', () => {
+        const existingConfig = `[mcp_servers.debugmcp]
+tool_timeout_sec = 180
+
+[mcp_servers.other]
+url = "http://localhost:4000/mcp"
+`;
+
+        const result = upsertCodexDebugMCPConfig(existingConfig, mcpServerUrl);
+
+        assert.strictEqual(result, `[mcp_servers.debugmcp]
+url = "${mcpServerUrl}"
+tool_timeout_sec = 180
+
+[mcp_servers.other]
+url = "http://localhost:4000/mcp"
+`);
+    });
+
+    test('upsertCodexDebugMCPConfig should preserve unrelated MCP server sections', () => {
+        const existingConfig = `[mcp_servers.other]
+url = "http://localhost:4000/mcp"
+`;
+
+        const result = upsertCodexDebugMCPConfig(existingConfig, mcpServerUrl);
+
+        assert.strictEqual(result, `${existingConfig}
+[mcp_servers.debugmcp]
+url = "${mcpServerUrl}"
+`);
+    });
+
+    test('upsertCodexDebugMCPConfig should migrate an existing SSE URL', () => {
+        const existingConfig = `[mcp_servers.debugmcp]
+url = "http://localhost:3001/sse"
+`;
+
+        const result = upsertCodexDebugMCPConfig(existingConfig, mcpServerUrl);
+
+        assert.strictEqual(result, `[mcp_servers.debugmcp]
+url = "${mcpServerUrl}"
+`);
+    });
+});

--- a/src/utils/agentConfigurationManager.ts
+++ b/src/utils/agentConfigurationManager.ts
@@ -5,13 +5,24 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
-export interface AgentInfo {
+export interface BaseAgentInfo {
     id: string;
     name: string;
     displayName: string;
     configPath: string;
+    configFormat: 'json' | 'toml';
+}
+
+export interface JsonAgentInfo extends BaseAgentInfo {
+    configFormat: 'json';
     mcpServerFieldName: string; 
 }
+
+export interface TomlAgentInfo extends BaseAgentInfo {
+    configFormat: 'toml';
+}
+
+export type AgentInfo = JsonAgentInfo | TomlAgentInfo;
 
 export interface MCPServerConfig {
     autoApprove: string[];
@@ -19,6 +30,57 @@ export interface MCPServerConfig {
     timeout: number;
     type: string;
     url: string;
+}
+
+export function upsertCodexDebugMCPConfig(configContent: string, mcpServerUrl: string): string {
+    const normalizedConfigContent = configContent.replace(/\r\n/g, '\n');
+    const lines = normalizedConfigContent.split('\n');
+    const escapedUrl = escapeTomlString(mcpServerUrl);
+    const debugMCPSectionIndex = lines.findIndex(line => isCodexDebugMCPSectionHeader(line));
+
+    if (debugMCPSectionIndex === -1) {
+        const separator = normalizedConfigContent.length === 0
+            ? ''
+            : normalizedConfigContent.endsWith('\n') ? '\n' : '\n\n';
+
+        return `${normalizedConfigContent}${separator}[mcp_servers.debugmcp]\nurl = "${escapedUrl}"\n`;
+    }
+
+    const nextSectionIndex = findNextTomlSectionIndex(lines, debugMCPSectionIndex + 1);
+    const debugMCPSectionEndIndex = nextSectionIndex === -1 ? lines.length : nextSectionIndex;
+
+    for (let index = debugMCPSectionIndex + 1; index < debugMCPSectionEndIndex; index++) {
+        const urlMatch = lines[index].match(/^(\s*)url\s*=.*$/);
+        if (urlMatch) {
+            lines[index] = `${urlMatch[1]}url = "${escapedUrl}"`;
+            return lines.join('\n');
+        }
+    }
+
+    lines.splice(debugMCPSectionIndex + 1, 0, `url = "${escapedUrl}"`);
+    return lines.join('\n');
+}
+
+function escapeTomlString(value: string): string {
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function findNextTomlSectionIndex(lines: string[], startIndex: number): number {
+    for (let index = startIndex; index < lines.length; index++) {
+        if (isTomlSectionHeader(lines[index])) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+function isTomlSectionHeader(line: string): boolean {
+    return /^\s*\[\[?[^\]]+\]\]?\s*(?:#.*)?$/.test(line);
+}
+
+function isCodexDebugMCPSectionHeader(line: string): boolean {
+    return /^\s*\[mcp_servers\.debugmcp\]\s*(?:#.*)?$/.test(line);
 }
 
 export class AgentConfigurationManager {
@@ -115,6 +177,11 @@ export class AgentConfigurationManager {
         }
     }
 
+    private getCodexConfigPath(): string {
+        const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+        return path.join(codexHome, 'config.toml');
+    }
+
     /**
      * Get list of supported agents
      */
@@ -130,6 +197,7 @@ export class AgentConfigurationManager {
                 name: 'cline',
                 displayName: 'Cline',
                 configPath: path.join(configBasePath, 'Code', 'User', 'globalStorage', 'saoudrizwan.claude-dev', 'settings', 'cline_mcp_settings.json'),
+                configFormat: 'json',
                 mcpServerFieldName: 'mcpServers'
             },
             {
@@ -137,6 +205,7 @@ export class AgentConfigurationManager {
                 name: 'copilot',
                 displayName: 'GitHub Copilot',
                 configPath: path.join(configBasePath, 'Code', 'User', 'mcp.json'),
+                configFormat: 'json',
                 mcpServerFieldName: 'servers'
             },
             {
@@ -144,6 +213,7 @@ export class AgentConfigurationManager {
                 name: 'cursor',
                 displayName: 'Cursor',
                 configPath: path.join(configBasePath, 'Cursor', 'User', 'globalStorage', 'cursor.mcp', 'settings', 'mcp_settings.json'),
+                configFormat: 'json',
                 mcpServerFieldName: 'mcpServers'
             },
             {
@@ -151,7 +221,15 @@ export class AgentConfigurationManager {
                 name: 'antigravity',
                 displayName: 'Antigravity',
                 configPath: path.join(os.homedir(), '.gemini', 'antigravity', 'mcp_config.json'),
+                configFormat: 'json',
                 mcpServerFieldName: 'mcpServers'
+            },
+            {
+                id: 'codex',
+                name: 'codex',
+                displayName: 'Codex',
+                configPath: this.getCodexConfigPath(),
+                configFormat: 'toml'
             }
         ];
 
@@ -167,8 +245,12 @@ export class AgentConfigurationManager {
             disabled: false,
             timeout: this.timeoutInSeconds,
             type: "streamableHttp",
-            url: `http://localhost:${this.serverPort}/mcp`
+            url: this.getMCPServerUrl()
         };
+    }
+
+    private getMCPServerUrl(): string {
+        return `http://localhost:${this.serverPort}/mcp`;
     }
 
     /**
@@ -186,6 +268,22 @@ export class AgentConfigurationManager {
                 }
 
                 const configContent = await fs.promises.readFile(agent.configPath, 'utf8');
+
+                if (agent.configFormat === 'toml') {
+                    if (this.shouldMigrateCodexConfig(configContent)) {
+                        await fs.promises.writeFile(
+                            agent.configPath,
+                            upsertCodexDebugMCPConfig(configContent, this.getMCPServerUrl()),
+                            'utf8'
+                        );
+
+                        migrationCount++;
+                        console.log(`Successfully migrated ${agent.displayName} configuration`);
+                    }
+
+                    continue;
+                }
+
                 let config: any;
                 
                 try {
@@ -241,6 +339,27 @@ export class AgentConfigurationManager {
         }
     }
 
+    private shouldMigrateCodexConfig(configContent: string): boolean {
+        const normalizedConfigContent = configContent.replace(/\r\n/g, '\n');
+        const lines = normalizedConfigContent.split('\n');
+        const debugMCPSectionIndex = lines.findIndex(line => isCodexDebugMCPSectionHeader(line));
+
+        if (debugMCPSectionIndex === -1) {
+            return false;
+        }
+
+        const nextSectionIndex = findNextTomlSectionIndex(lines, debugMCPSectionIndex + 1);
+        const debugMCPSectionEndIndex = nextSectionIndex === -1 ? lines.length : nextSectionIndex;
+
+        for (let index = debugMCPSectionIndex + 1; index < debugMCPSectionEndIndex; index++) {
+            if (/^\s*url\s*=.*\/sse["']?\s*(?:#.*)?$/.test(lines[index])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Add DebugMCP server configuration to the specified agent's config
      */
@@ -250,6 +369,21 @@ export class AgentConfigurationManager {
             const configDir = path.dirname(agent.configPath);
             if (!fs.existsSync(configDir)) {
                 await fs.promises.mkdir(configDir, { recursive: true });
+            }
+
+            if (agent.configFormat === 'toml') {
+                const configContent = fs.existsSync(agent.configPath)
+                    ? await fs.promises.readFile(agent.configPath, 'utf8')
+                    : '';
+
+                await fs.promises.writeFile(
+                    agent.configPath,
+                    upsertCodexDebugMCPConfig(configContent, this.getMCPServerUrl()),
+                    'utf8'
+                );
+
+                console.log(`Successfully added DebugMCP configuration to ${agent.name}`);
+                return true;
             }
 
             let config: any = {};


### PR DESCRIPTION
## Summary
Adds Codex as a first-class DebugMCP agent configuration target.

DebugMCP already exposes a Streamable HTTP MCP endpoint at `/mcp`; this change lets the extension configure Codex automatically by writing the matching MCP server entry to Codex's `config.toml`.

## Changes
- Adds Codex to the agent setup flow
- Writes DebugMCP configuration to `~/.codex/config.toml`, or `${CODEX_HOME}/config.toml` when `CODEX_HOME` is set
- Preserves existing Codex TOML content while upserting `[mcp_servers.debugmcp]`
- Migrates an existing DebugMCP `/sse` Codex URL to `/mcp`
- Documents Codex setup in the README and architecture notes
- Adds focused tests for Codex TOML upsert behavior

## Validation
- `npm run compile`
- `npm run lint`
- `npm test` - 13 passing
- Manually verified the extension setup flow writes the Codex MCP config and Codex recognizes `debugmcp` as a `streamable_http` MCP server
