### PR TITLE
Skip artifact PR comments for forked branches

### DIFF
--- a/.github/workflows/pr-extension-build.yml
+++ b/.github/workflows/pr-extension-build.yml
@@ -40,7 +40,7 @@ jobs:
           path: '*.vsix'
 
       - name: Comment on PR with artifact link
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary
Avoids failing the PR Extension Build workflow when a pull request comes from a fork.

Forked PRs receive a restricted `GITHUB_TOKEN`, so the workflow cannot create or update issue comments even though the VSIX build and artifact upload succeed. This skips the artifact comment step for fork branches while preserving it for same-repository PRs.
