### PR TITLE
fix: Real support for .Net xUint test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,25 @@
 {
   "name": "debugmcpextension",
-  "version": "1.1.0",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debugmcpextension",
-      "version": "1.1.0",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/express": "^5.0.3",
         "express": "^5.2.1",
         "jsonc-parser": "^3.3.1",
+        "ps-list": "^9.0.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^25.3.0",
+        "@types/ps-list": "^6.0.0",
         "@types/vscode": "^1.104.0",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
         "@typescript-eslint/parser": "^8.56.0",
@@ -424,6 +426,13 @@
       "dependencies": {
         "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/ps-list": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/ps-list/-/ps-list-6.0.0.tgz",
+      "integrity": "sha512-FuoItqYGkFXGrrlTraXZ5d4b7bNc9MBRWLAusHZWI9j8+LFoF+z938cizoetAQ3ui6K0BomAw5sFQYS2NVbV3Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -3163,6 +3172,18 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ps-list": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-9.0.0.tgz",
+      "integrity": "sha512-lxMEoIL/BQlk2KunFzxwUPwMvjFH7x7cmvzSLsSHpyMXl9FFfLUlfKrYwFc4wx/ZaIxxuXC4n8rjQ1CX/tkXVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "debugmcpextension",
   "displayName": "DebugMCP",
   "description": "Let AI agents debug your code inside VS Code — breakpoints, step-through execution, variable inspection, and expression evaluation. Automatically exposes itself as an MCP (Model Context Protocol) server for seamless integration with AI assistants.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "publisher": "ozzafar",
   "author": {
     "name": "Oz Zafar",
@@ -93,11 +93,13 @@
     "@types/express": "^5.0.3",
     "express": "^5.2.1",
     "jsonc-parser": "^3.3.1",
+    "ps-list": "^9.0.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.3.0",
+    "@types/ps-list": "^6.0.0",
     "@types/vscode": "^1.104.0",
     "@typescript-eslint/eslint-plugin": "^8.56.0",
     "@typescript-eslint/parser": "^8.56.0",

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -28,6 +28,7 @@ export class DebugMCPServer {
     private debuggingHandler: IDebuggingHandler;
     private transports: Map<string, StreamableHTTPServerTransport> = new Map();
     private testHostAutoAttacher: TestHostAutoAttacher;
+    private allowNextTransport = true;
 
     constructor(port: number, timeoutInSeconds: number) {
         // Initialize the debugging components with dependency injection
@@ -351,16 +352,28 @@ export class DebugMCPServer {
             app.post('/mcp', async (req: any, res: any) => {
                 logger.info('New MCP request received');
 
-                const transport = new StreamableHTTPServerTransport({
-                    sessionIdGenerator: undefined, // Stateless mode - no session management
-                });
-                res.on('close', () => {
-                    transport.close();
-                    logger.info('MCP transport closed');
-                });
-
                 try {
+                    let waitCnt = 0;
+                    while (!this.allowNextTransport && waitCnt <= 15) {
+                        waitCnt++;
+                        await new Promise(resolve => setTimeout(resolve, 200));
+                    }
+
+                    if (!this.allowNextTransport) {
+                        throw new Error("Error wait for transport release");
+                    }
+
+                    const transport = new StreamableHTTPServerTransport({
+                        sessionIdGenerator: undefined, // Stateless mode - no session management
+                    });
+                    res.on('close', () => {
+                        transport.close();
+                        this.allowNextTransport = true;
+                        logger.info('MCP transport closed');
+                    });
+
                     await this.mcpServer!.connect(transport);
+                    this.allowNextTransport = false;
                     await transport.handleRequest(req, res, req.body);
                 } catch (error) {
                     logger.error('Error while handling MCP request', error);

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -28,7 +28,8 @@ export class DebugMCPServer {
     private debuggingHandler: IDebuggingHandler;
     private transports: Map<string, StreamableHTTPServerTransport> = new Map();
     private testHostAutoAttacher: TestHostAutoAttacher;
-    private allowNextTransport = true;
+    private transportQueue: Array<{ resolve: () => void; reject: (err: Error) => void }> = [];
+    private processingRequest = false;
 
     constructor(port: number, timeoutInSeconds: number) {
         // Initialize the debugging components with dependency injection
@@ -351,29 +352,14 @@ export class DebugMCPServer {
             // Streamable HTTP endpoint — handles MCP protocol messages
             app.post('/mcp', async (req: any, res: any) => {
                 logger.info('New MCP request received');
+                await this.acquireTransportLock();
+
+                const transport = new StreamableHTTPServerTransport({
+                    sessionIdGenerator: undefined, // Stateless mode - no session management
+                });
 
                 try {
-                    let waitCnt = 0;
-                    while (!this.allowNextTransport && waitCnt <= 15) {
-                        waitCnt++;
-                        await new Promise(resolve => setTimeout(resolve, 200));
-                    }
-
-                    if (!this.allowNextTransport) {
-                        throw new Error("Error wait for transport release");
-                    }
-
-                    const transport = new StreamableHTTPServerTransport({
-                        sessionIdGenerator: undefined, // Stateless mode - no session management
-                    });
-                    res.on('close', () => {
-                        transport.close();
-                        this.allowNextTransport = true;
-                        logger.info('MCP transport closed');
-                    });
-
                     await this.mcpServer!.connect(transport);
-                    this.allowNextTransport = false;
                     await transport.handleRequest(req, res, req.body);
                 } catch (error) {
                     logger.error('Error while handling MCP request', error);
@@ -408,6 +394,10 @@ export class DebugMCPServer {
                             });
                         });
                     }
+                } finally {
+                    transport.close();
+                    this.releaseTransportLock();
+                    logger.info('MCP transport closed');
                 }
             });
 
@@ -480,5 +470,24 @@ export class DebugMCPServer {
      */
     isInitialized(): boolean {
         return this.initialized;
+    }
+    
+    private async acquireTransportLock(): Promise<void> {
+        if (!this.processingRequest) {
+            this.processingRequest = true;
+            return;
+        }
+        return new Promise<void>((resolve, reject) => {
+            this.transportQueue.push({ resolve, reject });
+        });
+    }
+
+    private releaseTransportLock(): void {
+        if (this.transportQueue.length > 0) {
+            const next = this.transportQueue.shift()!;
+            next.resolve();
+        } else {
+            this.processingRequest = false;
+        }
     }
 }

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -11,6 +11,7 @@ import {
     DebuggingHandler,
     IDebuggingHandler
 } from '.';
+import { TestHostAutoAttacher } from './testHostAutoAttacher';
 import { logger } from './utils/logger';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -26,12 +27,14 @@ export class DebugMCPServer {
     private initialized: boolean = false;
     private debuggingHandler: IDebuggingHandler;
     private transports: Map<string, StreamableHTTPServerTransport> = new Map();
+    private testHostAutoAttacher: TestHostAutoAttacher;
 
     constructor(port: number, timeoutInSeconds: number) {
         // Initialize the debugging components with dependency injection
         const executor = new DebuggingExecutor();
         const configManager = new ConfigurationManager();
         this.debuggingHandler = new DebuggingHandler(executor, configManager, timeoutInSeconds);
+        this.testHostAutoAttacher = new TestHostAutoAttacher();
         this.port = port;
     }
 
@@ -384,6 +387,11 @@ export class DebugMCPServer {
         // Note: With stateless StreamableHTTPServerTransport, transports are closed per-request
         // No need to track and close them manually
         this.transports.clear();
+
+        // Dispose the testhost auto attacher
+        if (this.testHostAutoAttacher) {
+            this.testHostAutoAttacher.dispose();
+        }
 
         // Close the HTTP server
         if (this.httpServer) {

--- a/src/testHostAutoAttacher.ts
+++ b/src/testHostAutoAttacher.ts
@@ -33,7 +33,7 @@ export class TestHostAutoAttacher {
 
                 logger.info(`Found testhost PID=${pid}, attaching...`);
                 logger.info(`Session=${session.id}, Name=${session.name}`);
-                this.pidToSession.set(pid, session.id)
+                this.pidToSession.set(pid, session.id);
                 await this.attachToTestHost(pid, session);
                 logger.info(`Successfully attached to testhost (PID: ${pid})`);
             } catch (err) {
@@ -44,7 +44,7 @@ export class TestHostAutoAttacher {
         this.disposables.push(vscode.debug.onDidTerminateDebugSession(async (session) => {
             for (const [pid, sid] of this.pidToSession) {
                 if (sid === session.id) {
-                    this.pidToSession.delete(pid)
+                    this.pidToSession.delete(pid);
                 }
             }
         }));
@@ -59,7 +59,9 @@ export class TestHostAutoAttacher {
 
         const start = Date.now();
         while (Date.now() - start < timeoutMs) {
-            if (!vscode.debug.activeDebugSession) break;
+            if (!vscode.debug.activeDebugSession) {
+                break;
+            }
 
             const processes = await this.psList();
 

--- a/src/testHostAutoAttacher.ts
+++ b/src/testHostAutoAttacher.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as vscode from 'vscode';
+import { logger } from './utils/logger';
+
+/**
+ * Handles auto-attach to testhost process for .NET test debugging.
+ * Listens for coreclr launch sessions and automatically attaches to testhost.
+ */
+export class TestHostAutoAttacher {
+    private psList?: (options?: any | undefined) => Promise<any[]>;
+    private readonly disposables: vscode.Disposable[] = [];
+    private readonly pidToSession = new Map<number, string>();
+
+
+    constructor() {
+        this.disposables.push(vscode.debug.onDidStartDebugSession(async (session) => {
+
+            if (session.type !== 'coreclr' || !session.name.includes('DebugMCP .NET Test')) {
+                return;
+            }
+
+            try {
+                const pid = await this.waitForTestHost();
+                if (!vscode.debug.activeDebugSession || vscode.debug.activeDebugSession.id !== session.id) {
+                    return;
+                }
+
+                if (this.pidToSession.has(pid)) {
+                    logger.error(`PID has been attached before (PID: ${pid})`);
+                    return;
+                }
+
+                logger.info(`Found testhost PID=${pid}, attaching...`);
+                logger.info(`Session=${session.id}, Name=${session.name}`);
+                this.pidToSession.set(pid, session.id)
+                await this.attachToTestHost(pid, session);
+                logger.info(`Successfully attached to testhost (PID: ${pid})`);
+            } catch (err) {
+                logger.error('Failed to auto attach testhost', err);
+            }
+        }));
+
+        this.disposables.push(vscode.debug.onDidTerminateDebugSession(async (session) => {
+            for (const [pid, sid] of this.pidToSession) {
+                if (sid === session.id) {
+                    this.pidToSession.delete(pid)
+                }
+            }
+        }));
+    }
+
+
+    /**
+     * Wait for testhost process to appear
+     */
+    public async waitForTestHost(timeoutMs: number = 15000): Promise<number> {
+        this.psList = this.psList ?? await import('ps-list').then(m => m.default);
+
+        const start = Date.now();
+        while (Date.now() - start < timeoutMs) {
+            if (!vscode.debug.activeDebugSession) break;
+
+            const processes = await this.psList();
+
+            const testhost = processes
+                .filter(p =>
+                    p.name?.includes('testhost')
+                    && !this.pidToSession.has(p.pid)
+                )
+                .sort((a, b) => b.pid - a.pid)
+                .at(0);
+
+            if (testhost?.pid) {
+                return testhost.pid;
+            }
+
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+
+        throw new Error('testhost process not found');
+    }
+
+    /**
+     * Attach debugger to testhost process
+     */
+    public async attachToTestHost(pid: number, session: vscode.DebugSession): Promise<void> {
+        try {
+            const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+            await vscode.debug.startDebugging(workspaceFolder, {
+                type: 'coreclr',
+                request: 'attach',
+                name: 'DebugMCP Attach testhost',
+                processId: pid.toString()
+            });
+        } catch (error) {
+            throw new Error(`Failed to attach to testhost: ${error}`);
+        }
+    }
+
+    /**
+     * Dispose the listener
+     */
+    public dispose(): void {
+        for (const disposable of this.disposables) {
+            disposable.dispose();
+        }
+    }
+}

--- a/src/utils/debugConfigurationManager.ts
+++ b/src/utils/debugConfigurationManager.ts
@@ -111,7 +111,7 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
         
         // Build test-specific configurations based on language
         if (testName) {
-            return await this.createTestDebugConfig(detectedLanguage, fileFullPath, cwd, testName);
+            return await this.createTestDebugConfig(detectedLanguage, workingDirectory, fileFullPath, cwd, testName);
         }
 
         const configs: { [key: string]: vscode.DebugConfiguration } = {
@@ -267,6 +267,7 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
      */
     private async createTestDebugConfig(
         language: string,
+        workingDirectory: string,
         fileFullPath: string,
         cwd: string,
         testName: string
@@ -361,7 +362,7 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
                         '--filter', `FullyQualifiedName~${testName}`
                     ],
                     console: 'integratedTerminal',
-                    cwd: cwd,
+                    cwd: workingDirectory,
                     stopAtEntry: false,
                     env: {
                         VSTEST_HOST_DEBUG: '1'

--- a/src/utils/debugConfigurationManager.ts
+++ b/src/utils/debugConfigurationManager.ts
@@ -173,7 +173,7 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
         const cwd = path.dirname(fileFullPath);
         
         // Build test-specific configurations based on language
-        if (testName && detectedLanguage !== 'coreclr') {
+        if (testName) {
             return await this.createTestDebugConfig(detectedLanguage, fileFullPath, cwd, testName);
         }
 
@@ -419,13 +419,16 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
                     name: `DebugMCP .NET Test: ${testName}`,
                     program: 'dotnet',
                     args: [
-                        'test',
-                        '--filter', `FullyQualifiedName~${testName}`,
-                        '--no-build'
+                        'test',                        
+                        '--no-build',
+                        '--filter', `FullyQualifiedName~${testName}`
                     ],
                     console: 'integratedTerminal',
                     cwd: cwd,
-                    stopAtEntry: false
+                    stopAtEntry: false,
+                    env: {
+                        VSTEST_HOST_DEBUG: '1'
+                    }
                 };
 
             default:


### PR DESCRIPTION
## Current progress
The current version (1.1.3) does not work when running C# xUnit tests at all.
The reason is that the test process is not attached to the debugger.
This PR uses a workaround to attach it.

## Follow-up
Currently, it uses a presumed name (testhost) to scan processes and obtain the PID.
There should be a better approach in the future.