### PR TITLE
Harden MCP HTTP endpoint + fix start_debugging hangs for Testing-API runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,8 @@ Configure DebugMCP behavior in VSCode settings:
 ```json
 {
   "debugmcp.serverPort": 3001,
-  "debugmcp.timeoutInSeconds": 180
+  "debugmcp.timeoutInSeconds": 180,
+  "debugmcp.bindHost": "127.0.0.1"
 }
 ```
 
@@ -282,6 +283,14 @@ Configure DebugMCP behavior in VSCode settings:
 |---------|---------|-------------|
 | `debugmcp.serverPort` | `3001` | Port number for the MCP server |
 | `debugmcp.timeoutInSeconds` | `180` | Timeout for debugging operations |
+| `debugmcp.bindHost` | `127.0.0.1` | Network interface the HTTP server binds to. See [Security model](#security-model) before changing. |
+
+### Security model
+
+DebugMCP exposes powerful debugger primitives (`evaluate_expression`, `start_debugging`, …) over an unauthenticated local HTTP endpoint. To keep that surface safe, the server enforces two controls:
+
+1. **Loopback-only bind.** The HTTP server binds to `127.0.0.1` by default, so other hosts on your network cannot reach `http://<your-ip>:3001/mcp`. The `debugmcp.bindHost` setting lets you opt into a different interface (for example, when forwarding the port into a remote container), but doing so exposes the unauthenticated debugger to anything that can route to that address — do not point it at `0.0.0.0` or a LAN address on an untrusted network.
+2. **Host / Origin header validation.** Every request must carry a `Host` header naming a loopback address (`localhost`, `127.0.0.1`, or `[::1]`); requests with any other `Host` — including those that arrive via DNS rebinding from a malicious webpage — are rejected with HTTP 403. The same check is applied to the `Origin` header when present.
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Configure DebugMCP behavior in VSCode settings:
 {
   "debugmcp.serverPort": 3001,
   "debugmcp.timeoutInSeconds": 180,
-  "debugmcp.bindHost": "127.0.0.1"
+  "debugmcp.bindHost": ["127.0.0.1", "::1"]
 }
 ```
 
@@ -283,14 +283,14 @@ Configure DebugMCP behavior in VSCode settings:
 |---------|---------|-------------|
 | `debugmcp.serverPort` | `3001` | Port number for the MCP server |
 | `debugmcp.timeoutInSeconds` | `180` | Timeout for debugging operations |
-| `debugmcp.bindHost` | `127.0.0.1` | Network interface the HTTP server binds to. See [Security model](#security-model) before changing. |
+| `debugmcp.bindHost` | `["127.0.0.1", "::1"]` | Network interface(s) the HTTP server binds to. Accepts a string or array of strings. See [Security model](#security-model) before changing. |
 
 ### Security model
 
 DebugMCP exposes powerful debugger primitives (`evaluate_expression`, `start_debugging`, …) over an unauthenticated local HTTP endpoint. To keep that surface safe, the server enforces two controls:
 
-1. **Loopback-only bind.** The HTTP server binds to `127.0.0.1` by default, so other hosts on your network cannot reach `http://<your-ip>:3001/mcp`. The `debugmcp.bindHost` setting lets you opt into a different interface (for example, when forwarding the port into a remote container), but doing so exposes the unauthenticated debugger to anything that can route to that address — do not point it at `0.0.0.0` or a LAN address on an untrusted network.
-2. **Host / Origin header validation.** Every request must carry a `Host` header naming a loopback address (`localhost`, `127.0.0.1`, or `[::1]`); requests with any other `Host` — including those that arrive via DNS rebinding from a malicious webpage — are rejected with HTTP 403. The same check is applied to the `Origin` header when present.
+1. **Loopback-only bind.** The HTTP server binds to the IPv4 and IPv6 loopback addresses (`127.0.0.1` and `::1`) by default, so other hosts on your network cannot reach `http://<your-ip>:3001/mcp`. Binding both families ensures clients that resolve `localhost` to either family connect successfully. The `debugmcp.bindHost` setting (string or array of strings) lets you opt into a different interface (for example, when forwarding the port into a remote container), but doing so exposes the unauthenticated debugger to anything that can route to that address — do not point it at `0.0.0.0` or a LAN address on an untrusted network.
+2. **Host / Origin header validation.** Every request must carry a `Host` header naming a loopback address (`localhost`, `127.0.0.1`, or `[::1]`); any port suffix in the `Host` must also match the server's listening port. Requests with any other `Host` — including those that arrive via DNS rebinding from a malicious webpage — are rejected with HTTP 403. The same loopback check is applied to the `Origin` header when present.
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Let AI agents debug your code inside VS Code - set breakpoints, step through exe
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![VS Code](https://img.shields.io/badge/VS%20Code-1.104.0+-blue.svg)](https://code.visualstudio.com/)
-[![Version](https://img.shields.io/badge/version-1.1.4-green.svg)](https://github.com/microsoft/DebugMCP)
+[![Version](https://img.shields.io/badge/version-1.2.0-green.svg)](https://github.com/microsoft/DebugMCP)
 [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-Install-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ozzafar.debugmcpextension)
 
 > ⭐ **If you find DebugMCP useful, please [star the repo on GitHub](https://github.com/microsoft/DebugMCP)!** It helps others discover the project and motivates continued development.

--- a/docs/agent-resources/troubleshooting/python.md
+++ b/docs/agent-resources/troubleshooting/python.md
@@ -27,6 +27,29 @@
 }
 ```
 
+## Debugging a Specific Test (pytest / unittest):
+
+DebugMCP dispatches single-test debugging through VS Code's Test Explorer, which requires the Python extension to have **discovered** the test. If discovery hasn't run, `start_debugging` with a `testName` will appear to do nothing (the file opens, the cursor jumps to the test, but no debug session starts).
+
+Discovery requires the test framework to be enabled in workspace settings. Add **one** of the following to `.vscode/settings.json`:
+
+```jsonc
+// For pytest:
+{
+    "python.testing.pytestEnabled": true
+}
+
+// For unittest:
+{
+    "python.testing.unittestEnabled": true,
+    "python.testing.unittestArgs": ["-v", "-s", ".", "-p", "test_*.py"]
+}
+```
+
+Alternatively, run **"Python: Configure Tests"** from the VS Code command palette once — it will write the appropriate settings for you.
+
+Verify discovery worked by opening the Testing view (beaker icon in the sidebar): your tests should appear in the tree. If the tree is empty, the framework isn't configured correctly.
+
 ## Debugging Tips:
 - Use `print()` statements for quick debugging
 - Leverage Python's `pdb` module for command-line debugging

--- a/docs/architecture/debugConfigurationManager.md
+++ b/docs/architecture/debugConfigurationManager.md
@@ -2,75 +2,63 @@
 
 ## Purpose
 
-Manages debug launch configurations by reading from `launch.json` for explicitly named configs, creating defaults when needed, and supporting test-specific debugging across multiple languages and test frameworks.
+Produces the argument passed to `vscode.debug.startDebugging()` — either a launch.json configuration name or a minimal `DebugConfiguration` stub.
 
 ## Motivation
 
-Different languages and test frameworks require different debug configurations. Rather than forcing AI agents to understand these details, `DebugConfigurationManager` auto-detects the appropriate configuration based on file extension and test framework conventions.
+Earlier versions of this class manually parsed `launch.json`, scored configurations, and assembled fully populated per-language config objects. That duplicated work VS Code and the language debug extensions already do better:
+
+- **VS Code** resolves launch.json configurations by name when you pass a string to `startDebugging`.
+- **Language extensions** (Python, JS/TS, Java, .NET, Go, …) each register a `DebugConfigurationProvider` whose `resolveDebugConfiguration` hook fills in `cwd`, `console`, `env`, `stopOnEntry`, and other sensible defaults for a minimal stub.
+
+Delegating to those mechanisms keeps this class small and ensures defaults stay aligned with whatever the installed language extensions consider current.
 
 ## Responsibility
 
-- Read and parse `.vscode/launch.json` configurations
-- Auto-select the most relevant launch configuration for the target file/test
-- Respect an explicitly provided `configurationName` when supplied by the agent
-- Create default configurations when none exist
-- Detect programming language from file extensions
-- Generate test-specific configurations for various frameworks
-- Validate workspace setup for debugging
+- Return a launch.json configuration name when the caller provides one — VS Code looks it up itself.
+- Otherwise, return a minimal launch stub (`type`, `request`, `name`, `program`) for the file's language and let the language extension resolve the rest.
+- For `.NET` (`coreclr`), locate the project's built DLL since `program` cannot be a `.cs` source file.
+- Detect the debugger `type` from a file extension.
+
+**Test debugging is not handled here.** It is routed through `DebuggingExecutor.debugTestAtCursor`, which uses VS Code's built-in `testing.debugAtCursor` command to dispatch to whichever `TestController` owns the test under the cursor. That path supports any language whose extension registers a Test Explorer integration and correctly handles parent/child process attach (e.g. `dotnet test`'s testhost).
 
 ## Key Concepts
 
-### Configuration Sources
+### Return type
 
-1. **User's launch.json**: Preferred if available
-2. **Default Configuration**: Auto-generated based on file extension
-3. **Test Configuration**: Special handling for unit test files
+`getDebugConfig()` returns `string | vscode.DebugConfiguration`. Both forms are accepted by `vscode.debug.startDebugging(folder, nameOrConfiguration)`.
 
-### Language Detection
+### Language detection
 
-Maps file extensions to debug types:
+Maps file extensions to debugger `type` values:
 - `.py` → `python`
-- `.js/.ts/.jsx/.tsx` → `node` (pwa-node)
+- `.js/.ts/.jsx/.tsx` → `pwa-node`
 - `.java` → `java`
-- `.cs` → `coreclr`
+- `.cs/.csproj` → `coreclr`
 - `.cpp/.cc/.c` → `cppdbg`
 - `.go` → `go`
 - `.rs` → `lldb`
 - `.php` → `php`
 - `.rb` → `ruby`
 
-### Test Framework Support
+### Test framework support
 
-| Language | Frameworks |
-|----------|------------|
-| Python | unittest |
-| Node.js | Jest, Mocha (auto-detected) |
-| Java | JUnit |
-| .NET | xUnit, NUnit, MSTest |
+Test launches are dispatched via `DebuggingExecutor.debugTestAtCursor`, not via this class. Any language with a registered `TestController` is supported (Python unittest/pytest, Jest, Mocha, JUnit, C# Dev Kit, Go, Rust, ...).
 
-### Configuration Selection Flow
+### Selection flow
 
-When starting debugging, the manager:
-1. Loads available launch.json configurations
-2. Scores configurations based on language/type/request/test relevance
-3. Selects the best match automatically
-4. Falls back to an auto-detected default configuration when needed
+1. If `configurationName` is provided and is not the sentinel `Default Configuration`, return that name verbatim.
+2. Otherwise, if the file is C# (`coreclr`), walk up to find the `.csproj`, locate its built DLL under `bin/{Debug,Release}/<tfm>/`, and return a coreclr config pointing at that assembly.
+3. Otherwise, return `{ type, request: 'launch', name: 'DebugMCP Launch', program: fileFullPath }`.
 
-## Key Code Locations
+## Key code locations
 
 - Class definition: `src/utils/debugConfigurationManager.ts`
 - Interface: `IDebugConfigurationManager`
-- Default configs: `createDefaultDebugConfig()`
-- Test configs: `createTestDebugConfig()`
+- .NET assembly lookup: `findNearestCsproj()`, `findBuiltAssembly()`, `createDotNetLaunchConfig()`
 - Language detection: `detectLanguageFromFilePath()`
-- Configuration selection: `selectBestLaunchConfiguration()`
+- Test launches: see `DebuggingExecutor.debugTestAtCursor` in `src/debuggingExecutor.ts`
 
-## JSON Parsing
+## Python test name formatting
 
-Handles common launch.json quirks:
-- Strips comments (`//` and `/* */`)
-- Removes trailing commas before `}` or `]`
-
-## Python Test Name Formatting
-
-For Python tests, the manager auto-detects the class name from the test file to build the full test path (`module.ClassName.test_method`). This allows AI agents to specify just the test method name.
+Python test name handling now lives in the Python extension's `TestController`; we no longer format `module.ClassName.test_method` ourselves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@types/express": "^5.0.3",
         "express": "^5.2.1",
-        "jsonc-parser": "^3.3.1",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -500,6 +499,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -758,6 +758,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1516,6 +1517,7 @@
       "integrity": "sha512-20MV9SUdeN6Jd84xESsKhRly+/vxI+hwvpBMA93s+9dAcjdCuCojn4IqUGS3lvVaqjVYGYHSRMCpeFtF2rQYxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -1746,6 +1748,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2150,6 +2153,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
       "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2508,12 +2512,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jsonc-parser": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "license": "MIT"
     },
     "node_modules/jszip": {
@@ -3729,6 +3727,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3804,6 +3803,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4119,6 +4119,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debugmcpextension",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debugmcpextension",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,10 @@
           "description": "Port number for the DebugMCP server"
         },
         "debugmcp.bindHost": {
-          "type": "string",
-          "default": "127.0.0.1",
-          "markdownDescription": "Network interface the DebugMCP HTTP server binds to. **Defaults to `127.0.0.1` (loopback only).** ⚠️ **Security warning:** changing this to `0.0.0.0` or a LAN address exposes the unauthenticated MCP debugger — including arbitrary code execution via `evaluate_expression` and `start_debugging` — to every host on the network. Only change this if you fully understand the risk."
+          "type": ["string", "array"],
+          "items": { "type": "string" },
+          "default": ["127.0.0.1", "::1"],
+          "markdownDescription": "Network interface(s) the DebugMCP HTTP server binds to. **Defaults to `[\"127.0.0.1\", \"::1\"]` (IPv4 + IPv6 loopback only).** Accepts a single string or an array of strings. ⚠️ **Security warning:** changing this to `0.0.0.0` or a LAN address exposes the unauthenticated MCP debugger — including arbitrary code execution via `evaluate_expression` and `start_debugging` — to every host on the network. Only change this if you fully understand the risk."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "keywords": [
     "debug",
+    "debugmcp",
     "mcp",
     "debugging",
     "ai",
@@ -69,7 +70,7 @@
       "properties": {
         "debugmcp.timeoutInSeconds": {
           "type": "number",
-          "default": 180,
+          "default": 300,
           "description": "Timeout in seconds"
         },
         "debugmcp.serverPort": {
@@ -97,7 +98,6 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@types/express": "^5.0.3",
     "express": "^5.2.1",
-    "jsonc-parser": "^3.3.1",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "debugmcpextension",
   "displayName": "DebugMCP",
   "description": "Let AI agents debug your code inside VS Code — breakpoints, step-through execution, variable inspection, and expression evaluation. Automatically exposes itself as an MCP (Model Context Protocol) server for seamless integration with AI assistants.",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "publisher": "ozzafar",
   "author": {
     "name": "Oz Zafar",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
           "type": "number",
           "default": 3001,
           "description": "Port number for the DebugMCP server"
+        },
+        "debugmcp.bindHost": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "markdownDescription": "Network interface the DebugMCP HTTP server binds to. **Defaults to `127.0.0.1` (loopback only).** ⚠️ **Security warning:** changing this to `0.0.0.0` or a LAN address exposes the unauthenticated MCP debugger — including arbitrary code execution via `evaluate_expression` and `start_debugging` — to every host on the network. Only change this if you fully understand the risk."
         }
       }
     }

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -81,7 +81,6 @@ export function isLoopbackOrigin(originHeader: string | undefined): boolean {
 }
 
 export class DebugMCPServer {
-    private mcpServer: McpServer | null = null;
     private httpServer: http.Server | null = null;
     private port: number;
     private host: string;
@@ -98,29 +97,41 @@ export class DebugMCPServer {
     }
 
     /**
-     * Initialize the MCP server
+     * Initialize the MCP server factory.
+     *
+     * NOTE: We no longer hold a singleton McpServer here. The stateless
+     * StreamableHTTPServerTransport requires a fresh McpServer per request
+     * (calling .connect() twice on the same server throws "Already connected
+     * to a transport"). The /mcp handler builds one on demand via
+     * createMcpServer().
      */
     async initialize() {
         if (this.initialized) {
             return;
         }
+        this.initialized = true;
+    }
 
-        this.mcpServer = new McpServer({
+    /**
+     * Build a fresh McpServer with all tools and resources registered.
+     * Called once per incoming MCP request.
+     */
+    private createMcpServer(): McpServer {
+        const server = new McpServer({
             name: 'debugmcp',
             version: '1.0.0',
         });
-
-        this.setupTools();
-        this.setupResources();
-        this.initialized = true;
+        this.setupTools(server);
+        this.setupResources(server);
+        return server;
     }
 
     /**
      * Setup MCP tools that delegate to the debugging handler
      */
-    private setupTools() {
+    private setupTools(server: McpServer) {
         // Get debug instructions tool (for clients that don't support MCP resources like GitHub Copilot)
-        this.mcpServer!.registerTool('get_debug_instructions', {
+        server.registerTool('get_debug_instructions', {
             description: 'Get the debugging guide with step-by-step instructions for effective debugging. ' +
                 'Returns comprehensive guidance including breakpoint strategies, root cause analysis framework, ' +
                 'and best practices. Call this before starting a debug session.',
@@ -130,7 +141,7 @@ export class DebugMCPServer {
         });
 
         // Start debugging tool
-        this.mcpServer!.registerTool('start_debugging', {
+        server.registerTool('start_debugging', {
             description: 'IMPORTANT DEBUGGING TOOL - Start a debug session for a code file' +
                 '\n\nUSE THIS WHEN:' +
                 '\n• Any bug, error, or unexpected behavior occurs' +
@@ -159,7 +170,7 @@ export class DebugMCPServer {
         });
 
         // Stop debugging tool
-        this.mcpServer!.registerTool('stop_debugging', {
+        server.registerTool('stop_debugging', {
             description: 'Stop the current debug session',
         }, async () => {
             const result = await this.debuggingHandler.handleStopDebugging();
@@ -167,7 +178,7 @@ export class DebugMCPServer {
         });
 
         // Step over tool
-        this.mcpServer!.registerTool('step_over', {
+        server.registerTool('step_over', {
             description: 'Execute the current line of code without diving into it.',
         }, async () => {
             const result = await this.debuggingHandler.handleStepOver();
@@ -175,7 +186,7 @@ export class DebugMCPServer {
         });
 
         // Step into tool
-        this.mcpServer!.registerTool('step_into', {
+        server.registerTool('step_into', {
             description: 'Dive into the current line of code.',
         }, async () => {
             const result = await this.debuggingHandler.handleStepInto();
@@ -183,7 +194,7 @@ export class DebugMCPServer {
         });
 
         // Step out tool
-        this.mcpServer!.registerTool('step_out', {
+        server.registerTool('step_out', {
             description: 'Step out of the current function',
         }, async () => {
             const result = await this.debuggingHandler.handleStepOut();
@@ -191,7 +202,7 @@ export class DebugMCPServer {
         });
 
         // Continue execution tool
-        this.mcpServer!.registerTool('continue_execution', {
+        server.registerTool('continue_execution', {
             description: 'Resume program execution until the next breakpoint is hit or the program completes.',
         }, async () => {
             const result = await this.debuggingHandler.handleContinue();
@@ -199,7 +210,7 @@ export class DebugMCPServer {
         });
 
         // Restart debugging tool
-        this.mcpServer!.registerTool('restart_debugging', {
+        server.registerTool('restart_debugging', {
             description: 'Restart the debug session from the beginning with the same configuration.',
         }, async () => {
             const result = await this.debuggingHandler.handleRestart();
@@ -207,7 +218,7 @@ export class DebugMCPServer {
         });
 
         // Add breakpoint tool
-        this.mcpServer!.registerTool('add_breakpoint', {
+        server.registerTool('add_breakpoint', {
             description: 'Set a breakpoint to pause execution at a critical line of code. Essential for debugging: pause before potential errors, examine state at decision points, or verify code paths. Breakpoints let you inspect variables and control flow at exact moments.',
             inputSchema: {
                 fileFullPath: z.string().describe('Full path to the file'),
@@ -219,7 +230,7 @@ export class DebugMCPServer {
         });
 
         // Remove breakpoint tool
-        this.mcpServer!.registerTool('remove_breakpoint', {
+        server.registerTool('remove_breakpoint', {
             description: 'Remove a breakpoint that is no longer needed.',
             inputSchema: {
                 fileFullPath: z.string().describe('Full path to the file'),
@@ -231,7 +242,7 @@ export class DebugMCPServer {
         });
 
         // Clear all breakpoints tool
-        this.mcpServer!.registerTool('clear_all_breakpoints', {
+        server.registerTool('clear_all_breakpoints', {
             description: 'Clear all breakpoints at once. Use this after verifying the root cause to clean up before moving on to the next task.',
         }, async () => {
             const result = await this.debuggingHandler.handleClearAllBreakpoints();
@@ -239,7 +250,7 @@ export class DebugMCPServer {
         });
 
         // List breakpoints tool
-        this.mcpServer!.registerTool('list_breakpoints', {
+        server.registerTool('list_breakpoints', {
             description: 'View all currently set breakpoints across all files.',
         }, async () => {
             const result = await this.debuggingHandler.handleListBreakpoints();
@@ -247,7 +258,7 @@ export class DebugMCPServer {
         });
 
         // Get variables tool
-        this.mcpServer!.registerTool('get_variables_values', {
+        server.registerTool('get_variables_values', {
             description: 'Inspect all variable values at the current execution point. This is your window into program state - see what data looks like at runtime, verify assumptions, identify unexpected values, and understand why code behaves as it does.',
             inputSchema: {
                 scope: z.enum(['local', 'global', 'all']).optional().describe("Variable scope: 'local', 'global', or 'all'"),
@@ -258,7 +269,7 @@ export class DebugMCPServer {
         });
 
         // Evaluate expression tool
-        this.mcpServer!.registerTool('evaluate_expression', {
+        server.registerTool('evaluate_expression', {
             description: 'Powerful runtime expression evaluator: Test hypotheses, check computed values, call methods, or inspect object properties in the live debug context. Goes beyond simple variable inspection - evaluate any valid expression in the target language.',
             inputSchema: {
                 expression: z.string().describe('Expression to evaluate in the current programming language context'),
@@ -272,9 +283,9 @@ export class DebugMCPServer {
     /**
      * Setup MCP resources for documentation
      */
-    private setupResources() {
+    private setupResources(server: McpServer) {
         // Add MCP resources for debugging documentation
-        this.mcpServer!.registerResource('Debugging Instructions Guide', 'debugmcp://docs/debug_instructions', {
+        server.registerResource('Debugging Instructions Guide', 'debugmcp://docs/debug_instructions', {
             description: 'Step-by-step instructions for debugging with DebugMCP',
             mimeType: 'text/markdown',
         }, async (uri: URL) => {
@@ -298,7 +309,7 @@ export class DebugMCPServer {
         };
 
         languages.forEach(language => {
-            this.mcpServer!.registerResource(
+            server.registerResource(
                 languageTitles[language],
                 `debugmcp://docs/troubleshooting/${language}`,
                 {
@@ -438,20 +449,26 @@ export class DebugMCPServer {
                 next(error);
             });
 
-            // Streamable HTTP endpoint — handles MCP protocol messages
+            // Streamable HTTP endpoint — handles MCP protocol messages.
+            // A fresh McpServer + transport pair is built per request because
+            // StreamableHTTPServerTransport in stateless mode (sessionIdGenerator: undefined)
+            // owns its connection; reusing a single McpServer across requests
+            // throws "Already connected to a transport" on the second call.
             app.post('/mcp', async (req: any, res: any) => {
                 logger.info('New MCP request received');
 
+                const server = this.createMcpServer();
                 const transport = new StreamableHTTPServerTransport({
                     sessionIdGenerator: undefined, // Stateless mode - no session management
                 });
                 res.on('close', () => {
                     transport.close();
+                    server.close();
                     logger.info('MCP transport closed');
                 });
 
                 try {
-                    await this.mcpServer!.connect(transport);
+                    await server.connect(transport);
                     await transport.handleRequest(req, res, req.body);
                 } catch (error) {
                     logger.error('Error while handling MCP request', error);

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -19,19 +19,82 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
  * Main MCP server class that exposes debugging functionality as tools and resources.
  * Uses the official @modelcontextprotocol/sdk with SSE transport over express.
  */
+/**
+ * Allow-list of host names that are considered loopback.
+ * Used to validate the Host and Origin headers on incoming requests
+ * to defend against DNS-rebinding-style attacks even when the
+ * server is bound to a non-loopback interface.
+ */
+const LOOPBACK_HOSTNAMES = new Set<string>([
+    'localhost',
+    '127.0.0.1',
+    '[::1]',
+    '::1'
+]);
+
+/**
+ * Extract just the hostname portion from a Host header value,
+ * stripping any port and surrounding brackets for IPv6 literals.
+ */
+function extractHostname(hostHeader: string): string {
+    const trimmed = hostHeader.trim().toLowerCase();
+    // IPv6 literal in brackets, optionally with :port suffix
+    if (trimmed.startsWith('[')) {
+        const closingBracketIndex = trimmed.indexOf(']');
+        if (closingBracketIndex === -1) {
+            return trimmed; // malformed — let caller reject
+        }
+        return trimmed.substring(0, closingBracketIndex + 1);
+    }
+    // IPv4 or DNS name with optional :port
+    const colonIndex = trimmed.indexOf(':');
+    return colonIndex === -1 ? trimmed : trimmed.substring(0, colonIndex);
+}
+
+/**
+ * Returns true when the given Host header value names a loopback address.
+ */
+export function isLoopbackHost(hostHeader: string | undefined): boolean {
+    if (!hostHeader) {
+        return false;
+    }
+    const hostname = extractHostname(hostHeader);
+    return LOOPBACK_HOSTNAMES.has(hostname);
+}
+
+/**
+ * Returns true when the given Origin header value names a loopback address.
+ * A missing Origin is allowed (most non-browser HTTP clients omit it).
+ */
+export function isLoopbackOrigin(originHeader: string | undefined): boolean {
+    if (!originHeader) {
+        return true;
+    }
+    try {
+        const url = new URL(originHeader);
+        // Strip brackets from IPv6 literal for set lookup
+        const hostname = url.hostname.toLowerCase();
+        return LOOPBACK_HOSTNAMES.has(hostname) || LOOPBACK_HOSTNAMES.has(`[${hostname}]`);
+    } catch {
+        return false;
+    }
+}
+
 export class DebugMCPServer {
     private mcpServer: McpServer | null = null;
     private httpServer: http.Server | null = null;
     private port: number;
+    private host: string;
     private initialized: boolean = false;
     private debuggingHandler: IDebuggingHandler;
 
-    constructor(port: number, timeoutInSeconds: number) {
+    constructor(port: number, timeoutInSeconds: number, host: string = '127.0.0.1') {
         // Initialize the debugging components with dependency injection
         const executor = new DebuggingExecutor();
         const configManager = new ConfigurationManager();
         this.debuggingHandler = new DebuggingHandler(executor, configManager, timeoutInSeconds);
         this.port = port;
+        this.host = host;
     }
 
     /**
@@ -68,7 +131,7 @@ export class DebugMCPServer {
 
         // Start debugging tool
         this.mcpServer!.registerTool('start_debugging', {
-            description: 'IMPORTANT DEBUGGING TOOL - Start a debug session for a code file' +
+            description: 'IIMPORTANT DEBUGGING TOOL - Start a debug session for a code file' +
                 '\n\nUSE THIS WHEN:' +
                 '\n• Any bug, error, or unexpected behavior occurs' +
                 '\n• Asked to debug a unit test' +
@@ -318,12 +381,44 @@ export class DebugMCPServer {
         }
 
         try {
-            logger.info(`Starting DebugMCP server on port ${this.port}...`);
+            logger.info(`Starting DebugMCP server on ${this.host}:${this.port}...`);
 
             // Dynamically import express (ES module)
             const expressModule = await import('express');
             const express = expressModule.default;
             const app = express();
+
+            // Reject requests whose Host or Origin header is not loopback.
+            // Defends against DNS-rebinding attacks: a malicious page that resolves
+            // its domain to 127.0.0.1 will still send Host/Origin = attacker.example,
+            // which we reject before any MCP handler runs.
+            app.use((req: any, res: any, next: any) => {
+                if (!isLoopbackHost(req.headers['host'])) {
+                    logger.warn(`Rejecting request with non-loopback Host header: ${req.headers['host']}`);
+                    res.status(403).json({
+                        jsonrpc: '2.0',
+                        error: {
+                            code: -32000,
+                            message: 'Forbidden: Host header is not a loopback address'
+                        },
+                        id: null
+                    });
+                    return;
+                }
+                if (!isLoopbackOrigin(req.headers['origin'])) {
+                    logger.warn(`Rejecting request with non-loopback Origin header: ${req.headers['origin']}`);
+                    res.status(403).json({
+                        jsonrpc: '2.0',
+                        error: {
+                            code: -32000,
+                            message: 'Forbidden: Origin header is not a loopback address'
+                        },
+                        id: null
+                    });
+                    return;
+                }
+                next();
+            });
 
             // Parse JSON body for incoming requests
             app.use(express.json());
@@ -404,15 +499,15 @@ export class DebugMCPServer {
                 });
             });
 
-            // Start HTTP server
+            // Start HTTP server, bound to the configured host (loopback by default)
             await new Promise<void>((resolve, reject) => {
-                this.httpServer = app.listen(this.port, () => {
+                this.httpServer = app.listen(this.port, this.host, () => {
                     resolve();
                 });
                 this.httpServer.on('error', reject);
             });
 
-            logger.info(`DebugMCP server started successfully on port ${this.port}`);
+            logger.info(`DebugMCP server started successfully on ${this.host}:${this.port}`);
 
         } catch (error) {
             logger.error(`Failed to start DebugMCP server`, error);

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -131,7 +131,7 @@ export class DebugMCPServer {
 
         // Start debugging tool
         this.mcpServer!.registerTool('start_debugging', {
-            description: 'IIMPORTANT DEBUGGING TOOL - Start a debug session for a code file' +
+            description: 'IMPORTANT DEBUGGING TOOL - Start a debug session for a code file' +
                 '\n\nUSE THIS WHEN:' +
                 '\n• Any bug, error, or unexpected behavior occurs' +
                 '\n• Asked to debug a unit test' +

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -33,33 +33,48 @@ const LOOPBACK_HOSTNAMES = new Set<string>([
 ]);
 
 /**
- * Extract just the hostname portion from a Host header value,
- * stripping any port and surrounding brackets for IPv6 literals.
+ * Split a Host header value into its hostname and optional port parts,
+ * stripping surrounding brackets for IPv6 literals.
  */
-function extractHostname(hostHeader: string): string {
+function parseHostHeader(hostHeader: string): { hostname: string; port: string | undefined } {
     const trimmed = hostHeader.trim().toLowerCase();
     // IPv6 literal in brackets, optionally with :port suffix
     if (trimmed.startsWith('[')) {
         const closingBracketIndex = trimmed.indexOf(']');
         if (closingBracketIndex === -1) {
-            return trimmed; // malformed — let caller reject
+            return { hostname: trimmed, port: undefined }; // malformed — let caller reject
         }
-        return trimmed.substring(0, closingBracketIndex + 1);
+        const hostname = trimmed.substring(0, closingBracketIndex + 1);
+        const rest = trimmed.substring(closingBracketIndex + 1);
+        const port = rest.startsWith(':') ? rest.substring(1) : undefined;
+        return { hostname, port };
     }
     // IPv4 or DNS name with optional :port
     const colonIndex = trimmed.indexOf(':');
-    return colonIndex === -1 ? trimmed : trimmed.substring(0, colonIndex);
+    if (colonIndex === -1) {
+        return { hostname: trimmed, port: undefined };
+    }
+    return { hostname: trimmed.substring(0, colonIndex), port: trimmed.substring(colonIndex + 1) };
 }
 
 /**
  * Returns true when the given Host header value names a loopback address.
+ * If expectedPort is provided, any port suffix in the header must match it
+ * (an absent port is allowed). This prevents requests aimed at a different
+ * port (e.g. Host: localhost:99999) from satisfying the allow-list.
  */
-export function isLoopbackHost(hostHeader: string | undefined): boolean {
+export function isLoopbackHost(hostHeader: string | undefined, expectedPort?: number): boolean {
     if (!hostHeader) {
         return false;
     }
-    const hostname = extractHostname(hostHeader);
-    return LOOPBACK_HOSTNAMES.has(hostname);
+    const { hostname, port } = parseHostHeader(hostHeader);
+    if (!LOOPBACK_HOSTNAMES.has(hostname)) {
+        return false;
+    }
+    if (expectedPort !== undefined && port !== undefined && port !== String(expectedPort)) {
+        return false;
+    }
+    return true;
 }
 
 /**
@@ -81,19 +96,19 @@ export function isLoopbackOrigin(originHeader: string | undefined): boolean {
 }
 
 export class DebugMCPServer {
-    private httpServer: http.Server | null = null;
+    private httpServers: http.Server[] = [];
     private port: number;
-    private host: string;
+    private hosts: string[];
     private initialized: boolean = false;
     private debuggingHandler: IDebuggingHandler;
 
-    constructor(port: number, timeoutInSeconds: number, host: string = '127.0.0.1') {
+    constructor(port: number, timeoutInSeconds: number, host: string | string[] = ['127.0.0.1', '::1']) {
         // Initialize the debugging components with dependency injection
         const executor = new DebuggingExecutor();
         const configManager = new ConfigurationManager();
         this.debuggingHandler = new DebuggingHandler(executor, configManager, timeoutInSeconds);
         this.port = port;
-        this.host = host;
+        this.hosts = Array.isArray(host) ? host : [host];
     }
 
     /**
@@ -392,7 +407,7 @@ export class DebugMCPServer {
         }
 
         try {
-            logger.info(`Starting DebugMCP server on ${this.host}:${this.port}...`);
+            logger.info(`Starting DebugMCP server on ${this.hosts.join(', ')}:${this.port}...`);
 
             // Dynamically import express (ES module)
             const expressModule = await import('express');
@@ -404,13 +419,13 @@ export class DebugMCPServer {
             // its domain to 127.0.0.1 will still send Host/Origin = attacker.example,
             // which we reject before any MCP handler runs.
             app.use((req: any, res: any, next: any) => {
-                if (!isLoopbackHost(req.headers['host'])) {
-                    logger.warn(`Rejecting request with non-loopback Host header: ${req.headers['host']}`);
+                if (!isLoopbackHost(req.headers['host'], this.port)) {
+                    logger.warn(`Rejecting request with non-loopback or wrong-port Host header: ${req.headers['host']}`);
                     res.status(403).json({
                         jsonrpc: '2.0',
                         error: {
                             code: -32000,
-                            message: 'Forbidden: Host header is not a loopback address'
+                            message: 'Forbidden: Host header is not a loopback address on the expected port'
                         },
                         id: null
                     });
@@ -516,15 +531,30 @@ export class DebugMCPServer {
                 });
             });
 
-            // Start HTTP server, bound to the configured host (loopback by default)
-            await new Promise<void>((resolve, reject) => {
-                this.httpServer = app.listen(this.port, this.host, () => {
-                    resolve();
+            // Start HTTP server(s), bound to each configured host (loopback IPv4 + IPv6 by default).
+            // Binding to '127.0.0.1' alone does not cover clients that resolve `localhost` to `::1`
+            // (common on IPv6-preferred systems), so we listen on both loopback families explicitly.
+            for (const host of this.hosts) {
+                await new Promise<void>((resolve, reject) => {
+                    const server = app.listen(this.port, host, () => {
+                        this.httpServers.push(server);
+                        resolve();
+                    });
+                    server.on('error', (err: NodeJS.ErrnoException) => {
+                        // EADDRINUSE on the IPv6 loopback is expected on some platforms (e.g. Linux
+                        // with net.ipv6.bindv6only=0) where the IPv4 bind already covers IPv6 via
+                        // dual-stack mapping. Treat as a soft warning instead of a hard failure.
+                        if (err.code === 'EADDRINUSE' && this.httpServers.length > 0) {
+                            logger.warn(`Skipping bind on ${host}:${this.port} (already covered by another loopback bind)`);
+                            resolve();
+                            return;
+                        }
+                        reject(err);
+                    });
                 });
-                this.httpServer.on('error', reject);
-            });
+            }
 
-            logger.info(`DebugMCP server started successfully on ${this.host}:${this.port}`);
+            logger.info(`DebugMCP server started successfully on ${this.hosts.join(', ')}:${this.port}`);
 
         } catch (error) {
             logger.error(`Failed to start DebugMCP server`, error);
@@ -536,12 +566,12 @@ export class DebugMCPServer {
      * Stop the MCP server
      */
     async stop() {
-        // Close the HTTP server
-        if (this.httpServer) {
-            await new Promise<void>((resolve) => {
-                this.httpServer!.close(() => resolve());
-            });
-            this.httpServer = null;
+        // Close all HTTP servers
+        if (this.httpServers.length > 0) {
+            await Promise.all(this.httpServers.map(server =>
+                new Promise<void>((resolve) => server.close(() => resolve()))
+            ));
+            this.httpServers = [];
         }
 
         logger.info('DebugMCP server stopped');

--- a/src/debuggingExecutor.ts
+++ b/src/debuggingExecutor.ts
@@ -2,12 +2,29 @@
 
 import * as vscode from 'vscode';
 import { DebugState, StackFrame } from './debugState';
+import { logger } from './utils/logger';
+
+/**
+ * Outcome of dispatching `testing.debugAtCursor`.
+ *
+ * `started` indicates the command was dispatched successfully.
+ * `runComplete` resolves when the underlying test run *finishes* (pass, fail,
+ * or aborted). For .NET this includes the `dotnet test` parent/testhost
+ * teardown. The handler races this against waitForDebugSessionReady so a test
+ * that runs to completion without hitting a breakpoint is reported as
+ * 'terminated' immediately instead of waiting for the configured timeout.
+ */
+export interface TestDebugDispatch {
+    started: boolean;
+    runComplete: Promise<void>;
+}
 
 /**
  * Interface for debugging execution operations
  */
 export interface IDebuggingExecutor {
-    startDebugging(workingDirectory: string, config: vscode.DebugConfiguration): Promise<boolean>;
+    startDebugging(workingDirectory: string, config: string | vscode.DebugConfiguration): Promise<boolean>;
+    debugTestAtCursor(fileFullPath: string, testName: string): Promise<TestDebugDispatch>;
     stopDebugging(session?: vscode.DebugSession): Promise<void>;
     stepOver(): Promise<void>;
     stepInto(): Promise<void>;
@@ -23,6 +40,7 @@ export interface IDebuggingExecutor {
     clearAllBreakpoints(): void;
     hasActiveSession(): Promise<boolean>;
     getActiveSession(): vscode.DebugSession | undefined;
+    waitForDebugSessionReady(timeoutMs: number): Promise<'stopped' | 'terminated' | 'timeout' | 'no-session'>;
 }
 
 /**
@@ -35,7 +53,7 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      */
     public async startDebugging(
         workingDirectory: string, 
-        config: vscode.DebugConfiguration
+        config: string | vscode.DebugConfiguration
     ): Promise<boolean> {
         try {
             const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(workingDirectory));
@@ -43,6 +61,159 @@ export class DebuggingExecutor implements IDebuggingExecutor {
         } catch (error) {
             throw new Error(`Failed to start debugging: ${error}`);
         }
+    }
+
+    /**
+     * Debug a single test by routing through VS Code's Testing API.
+     *
+     * Works for any language whose extension registers a TestController
+     * (Python, Jest/Mocha, JUnit, C# Dev Kit, Go, Rust, ...). This is the
+     * only correct way to debug `dotnet test` and similar runners where
+     * the actual test code runs in a child process — the language's test
+     * integration handles the parent/child debugger attach.
+     *
+     * Implementation strategy:
+     *  1. Open the file in an editor.
+     *  2. Place the cursor on the test method's definition line.
+     *  3. Execute the built-in `testing.debugAtCursor` command.
+     *
+     * The handler's existing readiness wait picks up the resulting session.
+     */
+    public async debugTestAtCursor(fileFullPath: string, testName: string): Promise<TestDebugDispatch> {
+        const positioned = await this.positionCursorAtTest(fileFullPath, testName);
+        if (!positioned) {
+            throw new Error(
+                `Could not locate test '${testName}' in ${fileFullPath}. ` +
+                `Check the test name, or pass a launch.json configurationName instead.`
+            );
+        }
+
+        // Trigger test discovery before dispatching. Some controllers (notably
+        // Python's) lazily discover tests on first Test Explorer open; without
+        // this, testing.debugAtCursor silently no-ops because no TestItem exists
+        // at the cursor yet. refreshTests typically resolves once discovery is
+        // complete, but we add a small grace period for controllers that report
+        // completion before all TestItems are registered.
+        try {
+            await vscode.commands.executeCommand('testing.refreshTests');
+            await new Promise(resolve => setTimeout(resolve, 300));
+        } catch {
+            // Not fatal — debugAtCursor may still work if tests were already discovered.
+        }
+
+        // `testing.debugAtCursor` resolves only when the entire test run
+        // *completes*, not when the debug session starts. We must not await
+        // it here — if the test hits a breakpoint, awaiting would block the
+        // handler forever. Instead, return the completion promise so the
+        // handler can race it against waitForDebugSessionReady: a clean run
+        // that never pauses will be reported as 'terminated' immediately.
+        const runComplete = Promise.resolve(vscode.commands.executeCommand('testing.debugAtCursor'))
+            .then(() => undefined)
+            .catch(err => {
+                logger.error(`testing.debugAtCursor failed: ${err}`);
+            });
+        return { started: true, runComplete };
+    }
+
+    /**
+     * Open the file and move the active editor's cursor to the line that
+     * defines `testName`. Tries language-aware patterns first, then falls
+     * back to a literal substring search (covers JS/TS `it('name')` style
+     * where the test name is a string literal, not an identifier).
+     *
+     * The cursor is placed on the test name itself (not on the preceding
+     * `void`/`def`/etc. keyword) because some TestController implementations
+     * — notably C# Dev Kit — register tight TestItem ranges around the
+     * method name. A cursor outside that range causes testing.debugAtCursor
+     * to fall back to the first test in the file.
+     *
+     * The cursor position is passed via the `selection` option to
+     * showTextDocument so it's applied atomically with the open — separate
+     * `editor.selection = ...` writes race testing.debugAtCursor.
+     */
+    private async positionCursorAtTest(fileFullPath: string, testName: string): Promise<boolean> {
+        const uri = vscode.Uri.file(fileFullPath);
+        const doc = await vscode.workspace.openTextDocument(uri);
+
+        const escaped = testName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const patterns = [
+            // identifier-style definitions: def/void/func/fn/fun/etc NAME(
+            new RegExp(`\\b(?:def|void|func|fn|fun|sub|Task|async|public|private|protected|internal|static)\\b[^\\n]*?\\b(${escaped})\\s*\\(`),
+            // bare identifier followed by (
+            new RegExp(`\\b(${escaped})\\s*\\(`),
+            // last resort: any substring match (covers it('add two numbers', ...))
+            new RegExp(`(${escaped})`)
+        ];
+
+        let target: vscode.Position | undefined;
+        for (const pattern of patterns) {
+            for (let i = 0; i < doc.lineCount; i++) {
+                const line = doc.lineAt(i).text;
+                const match = pattern.exec(line);
+                if (match) {
+                    // Place cursor one line below the method signature, inside
+                    // the body. The method-name line itself can be outside the
+                    // TestItem range used by some test controllers (notably
+                    // C# Dev Kit), causing testing.debugAtCursor to fall back
+                    // to the first test in the file. Landing inside the body
+                    // is reliably within the TestItem range across languages.
+                    const bodyLine = Math.min(i + 1, doc.lineCount - 1);
+                    const bodyText = doc.lineAt(bodyLine).text;
+                    const indent = bodyText.match(/^\s*/)?.[0].length ?? 0;
+                    target = new vscode.Position(bodyLine, indent);
+                    break;
+                }
+            }
+            if (target) {
+                break;
+            }
+        }
+
+        if (!target) {
+            return false;
+        }
+
+        const selection = new vscode.Range(target, target);
+        const editor = await vscode.window.showTextDocument(doc, {
+            selection,
+            preserveFocus: false,
+            preview: false
+        });
+
+        // Belt-and-suspenders: showTextDocument's `selection` option sets the
+        // selection but doesn't always scroll the viewport, especially when the
+        // editor was already open. Explicitly reveal to guarantee the cursor
+        // line is visible (and, more importantly, is the active line).
+        editor.revealRange(selection, vscode.TextEditorRevealType.InCenter);
+
+        // Wait until VS Code considers this editor active. testing.debugAtCursor
+        // reads the active editor synchronously, so without this small wait the
+        // command can race and pick whichever editor was previously focused.
+        await this.waitForActiveEditor(uri);
+        return true;
+    }
+
+    private async waitForActiveEditor(uri: vscode.Uri, timeoutMs = 1500): Promise<void> {
+        const matches = (editor: vscode.TextEditor | undefined) =>
+            editor?.document.uri.toString() === uri.toString();
+
+        if (matches(vscode.window.activeTextEditor)) {
+            return;
+        }
+
+        await new Promise<void>(resolve => {
+            const timer = setTimeout(() => {
+                disposable.dispose();
+                resolve();
+            }, timeoutMs);
+            const disposable = vscode.window.onDidChangeActiveTextEditor(editor => {
+                if (matches(editor)) {
+                    clearTimeout(timer);
+                    disposable.dispose();
+                    resolve();
+                }
+            });
+        });
     }
 
     /**
@@ -220,7 +391,6 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      */
     private async extractFrameName(session: vscode.DebugSession, frameId: number, state: DebugState): Promise<void> {
         try {
-            // Get full stack trace (up to 50 frames)
             const stackTraceResponse = await session.customRequest('stackTrace', {
                 threadId: state.threadId,
                 startFrame: 0,
@@ -345,5 +515,98 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      */
     public getActiveSession(): vscode.DebugSession | undefined {
         return vscode.debug.activeDebugSession;
+    }
+
+    /**
+     * Wait for the debug session to reach a steady, caller-actionable state.
+     *
+     * Returns when one of the following happens:
+     *  - 'stopped':    A stack frame is available (paused at breakpoint / entry / exception).
+     *                  Subsequent calls (step, get_variables, evaluate) can act immediately.
+     *  - 'terminated': The session ended (program ran to completion without stopping).
+     *  - 'no-session': No debug session ever started within the wait window.
+     *  - 'timeout':    A session is running but never stopped or terminated in time.
+     *
+     * Implemented with VS Code events rather than polling so we react the moment
+     * the state actually changes — important because a fast-running program can
+     * start *and* terminate inside a polling interval.
+     */
+    public async waitForDebugSessionReady(
+        timeoutMs: number
+    ): Promise<'stopped' | 'terminated' | 'timeout' | 'no-session'> {
+        // Helper: a session is only truly "stopped and actionable" when we have
+        // a DebugStackFrame (frameId present). A bare DebugThread means a thread
+        // is selected but the adapter hasn't published a frame yet — calling
+        // stackTrace/variables at that point can stall or return empty.
+        const isStoppedWithFrame = () => {
+            const item = vscode.debug.activeStackItem;
+            return !!item && 'frameId' in item;
+        };
+
+        if (isStoppedWithFrame()) {
+            return 'stopped';
+        }
+
+        const subscriptions: vscode.Disposable[] = [];
+        let trackedSession: vscode.DebugSession | undefined = vscode.debug.activeDebugSession;
+
+        try {
+            return await new Promise<'stopped' | 'terminated' | 'timeout' | 'no-session'>(resolve => {
+                let settled = false;
+                const settle = (result: 'stopped' | 'terminated' | 'timeout' | 'no-session') => {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    clearTimeout(timer);
+                    logger.info(`Debug session ready: ${result}`);
+                    resolve(result);
+                };
+
+                const timer = setTimeout(() => {
+                    settle(trackedSession ? 'timeout' : 'no-session');
+                }, timeoutMs);
+
+                subscriptions.push(
+                    vscode.debug.onDidStartDebugSession(session => {
+                        logger.info(`onDidStartDebugSession: ${session.name}`);
+                        trackedSession = session;
+                        setTimeout(() => {
+                            if (isStoppedWithFrame()) {
+                                settle('stopped');
+                            }
+                        }, 100);
+                    })
+                );
+
+                subscriptions.push(
+                    vscode.debug.onDidChangeActiveStackItem(stackItem => {
+                        const kind = !stackItem
+                            ? 'cleared'
+                            : 'frameId' in stackItem ? 'frame' : 'thread';
+                        logger.info(`onDidChangeActiveStackItem: ${kind}`);
+                        // Only resolve when we have a stack frame. A bare
+                        // DebugThread can fire while the program is still
+                        // running, before the adapter publishes frame info.
+                        if (stackItem && 'frameId' in stackItem) {
+                            settle('stopped');
+                        }
+                    })
+                );
+
+                subscriptions.push(
+                    vscode.debug.onDidTerminateDebugSession(session => {
+                        logger.info(`onDidTerminateDebugSession: ${session.name}, activeSession=${vscode.debug.activeDebugSession?.name ?? 'none'}`);
+                        // Only treat as 'terminated' if no other session is active.
+                        // dotnet test spawns a parent + testhost; wait for both to end.
+                        if (!vscode.debug.activeDebugSession) {
+                            settle('terminated');
+                        }
+                    })
+                );
+            });
+        } finally {
+            subscriptions.forEach(d => d.dispose());
+        }
     }
 }

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 
 import * as vscode from 'vscode';
-import { IDebugConfigurationManager } from './utils/debugConfigurationManager';
+import { DebugConfigurationManager, IDebugConfigurationManager } from './utils/debugConfigurationManager';
 import { DebugState } from './debugState';
 import { IDebuggingExecutor } from './debuggingExecutor';
 import { logger } from './utils/logger';
@@ -51,30 +51,69 @@ export class DebuggingHandler implements IDebuggingHandler {
         configurationName?: string;
     }): Promise<string> {
         const { fileFullPath, workingDirectory, testName, configurationName } = args;
+        const hasExplicitConfig = !!configurationName &&
+            configurationName.trim() !== '' &&
+            configurationName !== DebugConfigurationManager.getAutoLaunchConfigName();
 		
         try {
-            // Get debug configuration from launch.json or create default
-            const debugConfig = await this.configManager.getDebugConfig(
-                workingDirectory, 
-                fileFullPath, 
-                configurationName,
-                testName
-            );
+            logger.info(`handleStartDebugging: file=${fileFullPath} test=${testName ?? '<none>'} config=${configurationName ?? '<auto>'}`);
 
-            const started = await this.executor.startDebugging(workingDirectory, debugConfig);
+            // Start listening BEFORE we trigger the debug session, otherwise
+            // `onDidStartDebugSession` / `onDidChangeActiveStackItem` can fire
+            // during the trigger call (testing.debugAtCursor / vscode.debug.startDebugging
+            // can resolve only after the session is already up) and we'd miss them.
+            const readyPromise = this.executor.waitForDebugSessionReady(this.timeoutInSeconds * 1000);
+
+            let started: boolean;
+            let configDescription: string;
+            let testRunComplete: Promise<void> | undefined;
+
+            if (testName && !hasExplicitConfig) {
+                // Route through VS Code's Testing API. This works for any language
+                // whose extension registers a TestController and correctly handles
+                // child-process attach for runners like `dotnet test`.
+                const dispatch = await this.executor.debugTestAtCursor(fileFullPath, testName);
+                started = dispatch.started;
+                testRunComplete = dispatch.runComplete;
+                configDescription = `testing.debugAtCursor (test: ${testName})`;
+            } else {
+                const debugConfig = await this.configManager.getDebugConfig(
+                    workingDirectory,
+                    fileFullPath,
+                    configurationName
+                );
+                started = await this.executor.startDebugging(workingDirectory, debugConfig);
+                const configName = typeof debugConfig === 'string' ? debugConfig : debugConfig.name;
+                configDescription = configName ? `configuration '${configName}'` : 'default configuration';
+            }
+
             if (started) {
-                // Wait for debug session to become active using exponential backoff
-                const sessionActive = await this.waitForActiveDebugSession();
-                
-                if (!sessionActive) {
-                    throw new Error('Debug session started but failed to become active within timeout period');
-                }
-                
-                // return also the current state
-                const configInfo = debugConfig.name ? ` using configuration '${debugConfig.name}'` : '';
+                // Race the readiness signal against the test run completion. For .NET
+                // (and any runner where onDidTerminateDebugSession doesn't fire
+                // reliably for parent/child sessions), the test-run-complete signal
+                // is what tells us a clean run finished without ever pausing.
+                const readyState = testRunComplete
+                    ? await Promise.race([
+                        readyPromise,
+                        testRunComplete.then(() => 'terminated' as const)
+                    ])
+                    : await readyPromise;
+
+                logger.info(`handleStartDebugging: readyState=${readyState}, fetching current state…`);
                 const testInfo = testName ? ` (test: ${testName})` : '';
                 const currentState = await this.executor.getCurrentDebugState(this.numNextLines);
-                return `Debug session started successfully for: ${fileFullPath}${configInfo}${testInfo}. Current state: ${currentState.toString()}`;
+                logger.info('handleStartDebugging: got current state, returning response');
+
+                switch (readyState) {
+                    case 'stopped':
+                        return `Debug session stopped at breakpoint for: ${fileFullPath} using ${configDescription}${testInfo}. Current state: ${currentState.toString()}`;
+                    case 'terminated':
+                        return `Debug session for ${fileFullPath} ran to completion without stopping (no breakpoint hit). Using ${configDescription}${testInfo}. Final state: ${currentState.toString()}`;
+                    case 'no-session':
+                        throw new Error('Debug session failed to start within the timeout period. Make sure the appropriate language extension is installed and any required build step succeeded.');
+                    case 'timeout':
+                        return `Debug session is running but did not stop or terminate within the timeout for: ${fileFullPath} using ${configDescription}${testInfo}. Current state: ${currentState.toString()}`;
+                }
             } else {
                 throw new Error('Failed to start debug session. Make sure the appropriate language extension is installed.');
             }
@@ -426,35 +465,6 @@ export class DebuggingHandler implements IDebuggingHandler {
      */
     public async isDebuggingActive(): Promise<boolean> {
         return await this.executor.hasActiveSession();
-    }
-
-    /**
-     * Wait for debug session to become active using exponential backoff starting from 1 second
-     */
-    private async waitForActiveDebugSession(): Promise<boolean> {
-        const baseDelay = 1000; // Start with 1 second
-        const maxDelay = 10000; // Cap at 10 seconds
-        
-        const startTime = Date.now();
-        let attempt = 0;
-        
-        while (Date.now() - startTime < this.timeoutInSeconds * 1000) {
-            if (await this.executor.hasActiveSession()) {
-                logger.info('Debug session is now active!');
-                return true;
-            }
-            
-            logger.info(`[Attempt ${attempt + 1}] Waiting for debug session to become active...`);
-
-            // Calculate delay using exponential backoff with jitter
-            const delay = Math.min(baseDelay * Math.pow(2, attempt), maxDelay);
-            const jitteredDelay = delay + Math.random() * 200; // Add up to 200ms jitter
-            
-            await new Promise(resolve => setTimeout(resolve, jitteredDelay));
-            attempt++;
-        }
-        
-        return false; // Timeout reached
     }
 
     /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,9 +17,18 @@ export async function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('debugmcp');
     const timeoutInSeconds = config.get<number>('timeoutInSeconds', 180);
     const serverPort = config.get<number>('serverPort', 3001);
+    const bindHost = config.get<string>('bindHost', '127.0.0.1');
 
     logger.info(`Using timeoutInSeconds: ${timeoutInSeconds} seconds`);
     logger.info(`Using serverPort: ${serverPort}`);
+    logger.info(`Using bindHost: ${bindHost}`);
+    if (bindHost !== '127.0.0.1' && bindHost !== '::1' && bindHost !== 'localhost') {
+        logger.warn(
+            `DebugMCP is bound to '${bindHost}' instead of loopback. ` +
+            `This exposes the unauthenticated debugger to other hosts on the network. ` +
+            `Set 'debugmcp.bindHost' back to '127.0.0.1' unless you fully trust the network.`
+        );
+    }
 
     // Initialize Agent Configuration Manager
     agentConfigManager = new AgentConfigurationManager(context, timeoutInSeconds, serverPort);
@@ -35,7 +44,7 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
         logger.info('Starting MCP server initialization...');
         
-        mcpServer = new DebugMCPServer(serverPort, timeoutInSeconds);
+        mcpServer = new DebugMCPServer(serverPort, timeoutInSeconds, bindHost);
         await mcpServer.initialize();
         await mcpServer.start();
         

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,16 +17,19 @@ export async function activate(context: vscode.ExtensionContext) {
     const config = vscode.workspace.getConfiguration('debugmcp');
     const timeoutInSeconds = config.get<number>('timeoutInSeconds', 180);
     const serverPort = config.get<number>('serverPort', 3001);
-    const bindHost = config.get<string>('bindHost', '127.0.0.1');
+    const bindHostSetting = config.get<string | string[]>('bindHost', ['127.0.0.1', '::1']);
+    const bindHosts = Array.isArray(bindHostSetting) ? bindHostSetting : [bindHostSetting];
 
     logger.info(`Using timeoutInSeconds: ${timeoutInSeconds} seconds`);
     logger.info(`Using serverPort: ${serverPort}`);
-    logger.info(`Using bindHost: ${bindHost}`);
-    if (bindHost !== '127.0.0.1' && bindHost !== '::1' && bindHost !== 'localhost') {
+    logger.info(`Using bindHost: ${bindHosts.join(', ')}`);
+    const loopbackHosts = new Set(['127.0.0.1', '::1', 'localhost']);
+    const nonLoopback = bindHosts.filter(h => !loopbackHosts.has(h));
+    if (nonLoopback.length > 0) {
         logger.warn(
-            `DebugMCP is bound to '${bindHost}' instead of loopback. ` +
+            `DebugMCP is bound to '${nonLoopback.join(', ')}' instead of loopback. ` +
             `This exposes the unauthenticated debugger to other hosts on the network. ` +
-            `Set 'debugmcp.bindHost' back to '127.0.0.1' unless you fully trust the network.`
+            `Set 'debugmcp.bindHost' back to the default loopback unless you fully trust the network.`
         );
     }
 
@@ -44,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
     try {
         logger.info('Starting MCP server initialization...');
         
-        mcpServer = new DebugMCPServer(serverPort, timeoutInSeconds, bindHost);
+        mcpServer = new DebugMCPServer(serverPort, timeoutInSeconds, bindHosts);
         await mcpServer.initialize();
         await mcpServer.start();
         

--- a/src/test/debugMCPServer.security.test.ts
+++ b/src/test/debugMCPServer.security.test.ts
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import * as http from 'http';
+import * as net from 'net';
+import * as os from 'os';
+import { DebugMCPServer, isLoopbackHost, isLoopbackOrigin } from '../debugMCPServer';
+
+suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
+
+    suite('isLoopbackHost', () => {
+        test('accepts loopback hostnames with or without port', () => {
+            assert.strictEqual(isLoopbackHost('localhost'), true);
+            assert.strictEqual(isLoopbackHost('localhost:3001'), true);
+            assert.strictEqual(isLoopbackHost('127.0.0.1'), true);
+            assert.strictEqual(isLoopbackHost('127.0.0.1:3001'), true);
+            assert.strictEqual(isLoopbackHost('[::1]'), true);
+            assert.strictEqual(isLoopbackHost('[::1]:3001'), true);
+            assert.strictEqual(isLoopbackHost('LOCALHOST'), true);
+        });
+
+        test('rejects non-loopback / attacker-controlled hostnames (DNS rebinding)', () => {
+            assert.strictEqual(isLoopbackHost('attacker.example'), false);
+            assert.strictEqual(isLoopbackHost('attacker.example:3001'), false);
+            assert.strictEqual(isLoopbackHost('rebind.local:3001'), false);
+            assert.strictEqual(isLoopbackHost('192.168.1.10:3001'), false);
+            assert.strictEqual(isLoopbackHost('10.0.0.1'), false);
+            assert.strictEqual(isLoopbackHost('169.254.169.254'), false);
+            assert.strictEqual(isLoopbackHost(''), false);
+            assert.strictEqual(isLoopbackHost(undefined), false);
+        });
+    });
+
+    suite('isLoopbackOrigin', () => {
+        test('absent Origin is allowed (typical non-browser MCP clients)', () => {
+            assert.strictEqual(isLoopbackOrigin(undefined), true);
+            assert.strictEqual(isLoopbackOrigin(''), true);
+        });
+
+        test('accepts loopback origins', () => {
+            assert.strictEqual(isLoopbackOrigin('http://localhost:3001'), true);
+            assert.strictEqual(isLoopbackOrigin('http://127.0.0.1:3001'), true);
+            assert.strictEqual(isLoopbackOrigin('http://[::1]:3001'), true);
+        });
+
+        test('rejects non-loopback origins and malformed values', () => {
+            assert.strictEqual(isLoopbackOrigin('https://attacker.example'), false);
+            assert.strictEqual(isLoopbackOrigin('http://192.168.1.10:3001'), false);
+            assert.strictEqual(isLoopbackOrigin('not a url'), false);
+        });
+    });
+
+    suite('HTTP server (live)', () => {
+        const port = 30099;
+        let server: DebugMCPServer;
+
+        suiteSetup(async () => {
+            server = new DebugMCPServer(port, 60, '127.0.0.1');
+            await server.initialize();
+            await server.start();
+        });
+
+        suiteTeardown(async () => {
+            await server.stop();
+        });
+
+        function postMcp(headers: http.OutgoingHttpHeaders): Promise<{ status: number; body: string }> {
+            const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+            const opts: http.RequestOptions = {
+                host: '127.0.0.1',
+                port,
+                path: '/mcp',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'Accept': 'application/json, text/event-stream',
+                    'Content-Length': Buffer.byteLength(body).toString(),
+                    ...headers
+                }
+            };
+            return new Promise((resolve, reject) => {
+                const req = http.request(opts, res => {
+                    let data = '';
+                    res.on('data', c => data += c);
+                    res.on('end', () => resolve({ status: res.statusCode || 0, body: data }));
+                });
+                req.on('error', reject);
+                req.write(body);
+                req.end();
+            });
+        }
+
+        test('ICM 603080: server is NOT reachable on non-loopback interface', async () => {
+            // Find a non-loopback IPv4 interface on this machine.
+            const interfaces = os.networkInterfaces();
+            let lanAddr: string | undefined;
+            for (const list of Object.values(interfaces)) {
+                for (const iface of list || []) {
+                    if (iface.family === 'IPv4' && !iface.internal) {
+                        lanAddr = iface.address;
+                        break;
+                    }
+                }
+                if (lanAddr) { break; }
+            }
+            if (!lanAddr) {
+                // No external interface present on this test agent — nothing to assert.
+                return;
+            }
+
+            await new Promise<void>((resolve) => {
+                const sock = new net.Socket();
+                sock.setTimeout(1500);
+                sock.once('connect', () => {
+                    sock.destroy();
+                    assert.fail(`DebugMCP accepted a TCP connection on non-loopback address ${lanAddr}:${port} — server is exposed to the LAN.`);
+                });
+                sock.once('error', () => { sock.destroy(); resolve(); });
+                sock.once('timeout', () => { sock.destroy(); resolve(); });
+                sock.connect(port, lanAddr!);
+            });
+        });
+
+        test('ICM 611073: request with attacker Host header is rejected (403)', async () => {
+            const res = await postMcp({ Host: 'attacker.example' });
+            assert.strictEqual(res.status, 403, `expected 403 for DNS-rebinding Host header, got ${res.status}: ${res.body}`);
+        });
+
+        test('ICM 611073: request with non-loopback Origin header is rejected (403)', async () => {
+            const res = await postMcp({ Host: '127.0.0.1', Origin: 'https://attacker.example' });
+            assert.strictEqual(res.status, 403, `expected 403 for attacker Origin, got ${res.status}: ${res.body}`);
+        });
+
+        test('loopback request with valid Host header is accepted', async () => {
+            const res = await postMcp({ Host: `127.0.0.1:${port}` });
+            // Anything other than 403 means the rebinding middleware let it through.
+            // We don't validate the exact response shape because MCP handshake semantics
+            // are outside the scope of this security test.
+            assert.notStrictEqual(res.status, 403, `loopback request was incorrectly rejected: ${res.body}`);
+        });
+    });
+});

--- a/src/test/debugMCPServer.security.test.ts
+++ b/src/test/debugMCPServer.security.test.ts
@@ -6,7 +6,7 @@ import * as net from 'net';
 import * as os from 'os';
 import { DebugMCPServer, isLoopbackHost, isLoopbackOrigin } from '../debugMCPServer';
 
-suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
+suite('DebugMCPServer security', () => {
 
     suite('isLoopbackHost', () => {
         test('accepts loopback hostnames with or without port', () => {
@@ -28,6 +28,18 @@ suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
             assert.strictEqual(isLoopbackHost('169.254.169.254'), false);
             assert.strictEqual(isLoopbackHost(''), false);
             assert.strictEqual(isLoopbackHost(undefined), false);
+        });
+
+        test('with expectedPort, rejects loopback host whose port does not match', () => {
+            assert.strictEqual(isLoopbackHost('localhost:3001', 3001), true);
+            assert.strictEqual(isLoopbackHost('127.0.0.1:3001', 3001), true);
+            assert.strictEqual(isLoopbackHost('[::1]:3001', 3001), true);
+            // Absent port is still allowed (some clients omit it for default ports).
+            assert.strictEqual(isLoopbackHost('localhost', 3001), true);
+            // Wrong port is rejected — prevents Host: localhost:99999 sneaking through.
+            assert.strictEqual(isLoopbackHost('localhost:99999', 3001), false);
+            assert.strictEqual(isLoopbackHost('127.0.0.1:8080', 3001), false);
+            assert.strictEqual(isLoopbackHost('[::1]:8080', 3001), false);
         });
     });
 
@@ -55,7 +67,7 @@ suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
         let server: DebugMCPServer;
 
         suiteSetup(async () => {
-            server = new DebugMCPServer(port, 60, '127.0.0.1');
+            server = new DebugMCPServer(port, 60);
             await server.initialize();
             await server.start();
         });
@@ -64,10 +76,10 @@ suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
             await server.stop();
         });
 
-        function postMcp(headers: http.OutgoingHttpHeaders): Promise<{ status: number; body: string }> {
+        function postMcp(headers: http.OutgoingHttpHeaders, hostAddr: string = '127.0.0.1'): Promise<{ status: number; body: string }> {
             const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
             const opts: http.RequestOptions = {
-                host: '127.0.0.1',
+                host: hostAddr,
                 port,
                 path: '/mcp',
                 method: 'POST',
@@ -90,7 +102,7 @@ suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
             });
         }
 
-        test('ICM 603080: server is NOT reachable on non-loopback interface', async () => {
+        test('server is NOT reachable on non-loopback interface (LAN exposure)', async () => {
             // Find a non-loopback IPv4 interface on this machine.
             const interfaces = os.networkInterfaces();
             let lanAddr: string | undefined;
@@ -121,14 +133,19 @@ suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
             });
         });
 
-        test('ICM 611073: request with attacker Host header is rejected (403)', async () => {
+        test('request with attacker Host header is rejected (403) — DNS rebinding defense', async () => {
             const res = await postMcp({ Host: 'attacker.example' });
             assert.strictEqual(res.status, 403, `expected 403 for DNS-rebinding Host header, got ${res.status}: ${res.body}`);
         });
 
-        test('ICM 611073: request with non-loopback Origin header is rejected (403)', async () => {
+        test('request with non-loopback Origin header is rejected (403)', async () => {
             const res = await postMcp({ Host: '127.0.0.1', Origin: 'https://attacker.example' });
             assert.strictEqual(res.status, 403, `expected 403 for attacker Origin, got ${res.status}: ${res.body}`);
+        });
+
+        test('request with loopback Host but mismatched port is rejected (403)', async () => {
+            const res = await postMcp({ Host: 'localhost:99999' });
+            assert.strictEqual(res.status, 403, `expected 403 for wrong-port Host header, got ${res.status}: ${res.body}`);
         });
 
         test('loopback request with valid Host header is accepted', async () => {
@@ -137,6 +154,19 @@ suite('DebugMCPServer security (ICM 31000000603080 / 31000000611073)', () => {
             // We don't validate the exact response shape because MCP handshake semantics
             // are outside the scope of this security test.
             assert.notStrictEqual(res.status, 403, `loopback request was incorrectly rejected: ${res.body}`);
+        });
+
+        test('server is reachable over IPv6 loopback (::1)', async () => {
+            try {
+                const res = await postMcp({ Host: `[::1]:${port}` }, '::1');
+                assert.notStrictEqual(res.status, 403, `IPv6 loopback request was incorrectly rejected: ${res.body}`);
+            } catch (err: any) {
+                // ENETUNREACH / EAFNOSUPPORT — host has no IPv6 stack; not a failure of the server.
+                if (err && (err.code === 'ENETUNREACH' || err.code === 'EAFNOSUPPORT' || err.code === 'EADDRNOTAVAIL')) {
+                    return;
+                }
+                throw err;
+            }
         });
     });
 });

--- a/src/test/startDebuggingMatrix.test.ts
+++ b/src/test/startDebuggingMatrix.test.ts
@@ -1,0 +1,314 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { DebugState } from '../debugState';
+import { DebuggingHandler } from '../debuggingHandler';
+import { IDebuggingExecutor, TestDebugDispatch } from '../debuggingExecutor';
+import { IDebugConfigurationManager } from '../utils/debugConfigurationManager';
+
+/**
+ * Regression matrix for handleStartDebugging.
+ *
+ * Covers four scenarios per language:
+ *   1. pause-hit     — session reaches a breakpoint
+ *   2. clean-run     — session runs to completion without pausing
+ *   3. launch-error  — the debug adapter fails to start
+ *   4. no-build      — config resolution fails (e.g. missing built assembly)
+ *
+ * Both the "launch" path (no testName) and the "test" path (testName + Testing
+ * API) are exercised. The test path additionally guards the race between
+ * waitForDebugSessionReady and the testing.debugAtCursor completion promise
+ * — this is the regression that caused .NET test runs to hang past breakpoint
+ * hit and past clean completion.
+ */
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason?: any) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: any) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+}
+
+type ReadyState = 'stopped' | 'terminated' | 'timeout' | 'no-session';
+
+interface MockOpts {
+    readyState?: Deferred<ReadyState>;
+    startResult?: boolean | Error;
+    testDispatch?: TestDebugDispatch | Error;
+    debugConfig?: string | vscode.DebugConfiguration | Error;
+    language?: string;
+}
+
+function makeMocks(opts: MockOpts) {
+    const state = new DebugState();
+    state.sessionActive = false;
+
+    const executor: IDebuggingExecutor = {
+        startDebugging: async () => {
+            if (opts.startResult instanceof Error) {
+                throw opts.startResult;
+            }
+            return opts.startResult ?? true;
+        },
+        debugTestAtCursor: async () => {
+            if (opts.testDispatch instanceof Error) {
+                throw opts.testDispatch;
+            }
+            // Default: never resolves runComplete unless caller provides one.
+            return opts.testDispatch ?? { started: true, runComplete: new Promise<void>(() => { /* pending */ }) };
+        },
+        waitForDebugSessionReady: () =>
+            opts.readyState?.promise ?? Promise.resolve('no-session' as ReadyState),
+        getCurrentDebugState: async () => state,
+        stopDebugging: async () => { /* noop */ },
+        stepOver: async () => { /* noop */ },
+        stepInto: async () => { /* noop */ },
+        stepOut: async () => { /* noop */ },
+        continue: async () => { /* noop */ },
+        restart: async () => { /* noop */ },
+        addBreakpoint: async () => { /* noop */ },
+        removeBreakpoint: async () => { /* noop */ },
+        getVariables: async () => ({}),
+        evaluateExpression: async () => ({}),
+        getBreakpoints: () => [],
+        clearAllBreakpoints: () => { /* noop */ },
+        hasActiveSession: async () => false,
+        getActiveSession: () => undefined
+    };
+
+    const configManager: IDebugConfigurationManager = {
+        getDebugConfig: async () => {
+            if (opts.debugConfig instanceof Error) {
+                throw opts.debugConfig;
+            }
+            return opts.debugConfig ?? {
+                type: opts.language ?? 'python',
+                request: 'launch',
+                name: 'DebugMCP Launch',
+                program: 'unused'
+            };
+        },
+        detectLanguageFromFilePath: () => opts.language ?? 'python'
+    };
+
+    return { executor, configManager };
+}
+
+interface LangCase {
+    label: string;
+    file: string;
+    debuggerType: string;
+}
+
+const LANGUAGES: LangCase[] = [
+    { label: 'Python',     file: '/repo/src/app.py',          debuggerType: 'python'   },
+    { label: 'JavaScript', file: '/repo/src/app.js',          debuggerType: 'pwa-node' },
+    { label: 'TypeScript', file: '/repo/src/app.ts',          debuggerType: 'pwa-node' },
+    { label: 'Java',       file: '/repo/src/App.java',        debuggerType: 'java'     },
+    { label: 'C#',         file: '/repo/src/AppTests.cs',     debuggerType: 'coreclr'  },
+    { label: 'C++',        file: '/repo/src/app.cpp',         debuggerType: 'cppdbg'   },
+    { label: 'Go',         file: '/repo/src/main.go',         debuggerType: 'go'       }
+];
+
+suite('handleStartDebugging regression matrix', () => {
+
+    // -------------------------------------------------------------------------
+    // Launch path (no testName) — uses executor.startDebugging + readyPromise.
+    // -------------------------------------------------------------------------
+    for (const lang of LANGUAGES) {
+
+        test(`[${lang.label}] launch path: pause-hit returns 'stopped'`, async () => {
+            const ready = deferred<ReadyState>();
+            const { executor, configManager } = makeMocks({
+                readyState: ready,
+                startResult: true,
+                language: lang.debuggerType
+            });
+            const handler = new DebuggingHandler(executor, configManager, 30);
+
+            const pending = handler.handleStartDebugging({
+                fileFullPath: lang.file,
+                workingDirectory: '/repo'
+            });
+            ready.resolve('stopped');
+            const result = await pending;
+
+            assert.match(result, /stopped at breakpoint/);
+            assert.match(result, new RegExp(escapeRegex(lang.file)));
+        });
+
+        test(`[${lang.label}] launch path: clean-run returns 'terminated'`, async () => {
+            const ready = deferred<ReadyState>();
+            const { executor, configManager } = makeMocks({
+                readyState: ready,
+                startResult: true,
+                language: lang.debuggerType
+            });
+            const handler = new DebuggingHandler(executor, configManager, 30);
+
+            const pending = handler.handleStartDebugging({
+                fileFullPath: lang.file,
+                workingDirectory: '/repo'
+            });
+            ready.resolve('terminated');
+            const result = await pending;
+
+            assert.match(result, /ran to completion without stopping/);
+        });
+
+        test(`[${lang.label}] launch path: launch-error surfaces failure`, async () => {
+            const { executor, configManager } = makeMocks({
+                startResult: false,
+                language: lang.debuggerType
+            });
+            const handler = new DebuggingHandler(executor, configManager, 30);
+
+            await assert.rejects(
+                handler.handleStartDebugging({
+                    fileFullPath: lang.file,
+                    workingDirectory: '/repo'
+                }),
+                /Failed to start debug session/
+            );
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // No-build / config-resolution failure (most relevant to .NET coreclr,
+    // but the handler must surface it uniformly for any language).
+    // -------------------------------------------------------------------------
+    test('[C#] launch path: no-build surfaces config error', async () => {
+        const { executor, configManager } = makeMocks({
+            debugConfig: new Error("Could not find a built assembly for App.csproj. Run 'dotnet build' first"),
+            language: 'coreclr'
+        });
+        const handler = new DebuggingHandler(executor, configManager, 30);
+
+        await assert.rejects(
+            handler.handleStartDebugging({
+                fileFullPath: '/repo/src/App.cs',
+                workingDirectory: '/repo'
+            }),
+            /Could not find a built assembly/
+        );
+    });
+
+    // -------------------------------------------------------------------------
+    // Test path (testName) — uses executor.debugTestAtCursor and races
+    // readyPromise against the test-run completion promise.
+    // -------------------------------------------------------------------------
+    for (const lang of LANGUAGES) {
+
+        test(`[${lang.label}] test path: pause-hit wins race, returns 'stopped'`, async () => {
+            const ready = deferred<ReadyState>();
+            const runComplete = deferred<void>();
+            const { executor, configManager } = makeMocks({
+                readyState: ready,
+                testDispatch: { started: true, runComplete: runComplete.promise },
+                language: lang.debuggerType
+            });
+            const handler = new DebuggingHandler(executor, configManager, 30);
+
+            const pending = handler.handleStartDebugging({
+                fileFullPath: lang.file,
+                workingDirectory: '/repo',
+                testName: 'My_Test'
+            });
+            // Breakpoint hits BEFORE the test-run completes (the .NET case
+            // where awaiting testing.debugAtCursor would have hung).
+            ready.resolve('stopped');
+            const result = await pending;
+
+            assert.match(result, /stopped at breakpoint/);
+            assert.match(result, /test: My_Test/);
+            // Cleanup: avoid an unhandled-rejection-like dangling promise.
+            runComplete.resolve();
+        });
+
+        test(`[${lang.label}] test path: clean-run wins race, returns 'terminated'`, async () => {
+            const neverReady = deferred<ReadyState>(); // simulate no terminate event
+            const runComplete = deferred<void>();
+            const { executor, configManager } = makeMocks({
+                readyState: neverReady,
+                testDispatch: { started: true, runComplete: runComplete.promise },
+                language: lang.debuggerType
+            });
+            const handler = new DebuggingHandler(executor, configManager, 30);
+
+            const pending = handler.handleStartDebugging({
+                fileFullPath: lang.file,
+                workingDirectory: '/repo',
+                testName: 'My_Test'
+            });
+            // Test runs to completion without ever pausing AND without
+            // waitForDebugSessionReady firing 'terminated' — this is the
+            // .NET parent/child-session edge case. Must still return promptly.
+            runComplete.resolve();
+            const result = await pending;
+
+            assert.match(result, /ran to completion without stopping/);
+            assert.match(result, /test: My_Test/);
+            // Cleanup the dangling readyPromise.
+            neverReady.resolve('timeout');
+        });
+
+        test(`[${lang.label}] test path: launch-error surfaces failure`, async () => {
+            const { executor, configManager } = makeMocks({
+                testDispatch: new Error(`Could not locate test 'My_Test' in ${lang.file}`),
+                language: lang.debuggerType
+            });
+            const handler = new DebuggingHandler(executor, configManager, 30);
+
+            await assert.rejects(
+                handler.handleStartDebugging({
+                    fileFullPath: lang.file,
+                    workingDirectory: '/repo',
+                    testName: 'My_Test'
+                }),
+                /Could not locate test/
+            );
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Race tie-breakers — same readyState resolved at the same microtask tick
+    // must not produce a hang or double-resolve. Use Promise.all to ensure
+    // we don't regress to awaiting the slower promise.
+    // -------------------------------------------------------------------------
+    test('test path: readyPromise resolving first beats already-pending runComplete', async () => {
+        const ready = deferred<ReadyState>();
+        const runComplete = deferred<void>();
+        const { executor, configManager } = makeMocks({
+            readyState: ready,
+            testDispatch: { started: true, runComplete: runComplete.promise },
+            language: 'coreclr'
+        });
+        const handler = new DebuggingHandler(executor, configManager, 30);
+
+        const pending = handler.handleStartDebugging({
+            fileFullPath: '/repo/AppTests.cs',
+            workingDirectory: '/repo',
+            testName: 'Foo'
+        });
+        ready.resolve('stopped');
+        // Even if runComplete later resolves, the handler must already be done.
+        runComplete.resolve();
+
+        const result = await pending;
+        assert.match(result, /stopped at breakpoint/);
+    });
+});
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils/debugConfigurationManager.ts
+++ b/src/utils/debugConfigurationManager.ts
@@ -3,68 +3,86 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as jsonc from 'jsonc-parser';
 
 /**
  * Interface for configuration management operations
  */
 export interface IDebugConfigurationManager {
     getDebugConfig(
-        workingDirectory: string, 
-        fileFullPath: string, 
-        configurationName?: string,
-        testName?: string
-    ): Promise<vscode.DebugConfiguration>;
+        workingDirectory: string,
+        fileFullPath: string,
+        configurationName?: string
+    ): Promise<string | vscode.DebugConfiguration>;
     detectLanguageFromFilePath(fileFullPath: string): string;
 }
 
 /**
- * Responsible for managing debug configurations and workspace detection
+ * Responsible for producing the argument passed to vscode.debug.startDebugging()
+ * for *non-test* launches.
+ *
+ * We deliberately keep configurations minimal and rely on:
+ *  - VS Code's own launch.json resolution (when the caller passes a config name)
+ *  - The language extension's DebugConfigurationProvider.resolveDebugConfiguration
+ *    (which fills in cwd, console, env, and other defaults for ad-hoc launches)
+ *
+ * Test launches go through DebuggingExecutor.debugTestAtCursor instead — VS Code's
+ * Testing API knows how to debug a specific test for any language whose extension
+ * registers a TestController, including the parent/child process handoff that
+ * `dotnet test` requires.
  */
 export class DebugConfigurationManager implements IDebugConfigurationManager {
-	private static readonly AUTO_LAUNCH_CONFIG = 'Default Configuration';
+    private static readonly AUTO_LAUNCH_CONFIG = 'Default Configuration';
+
+    private static readonly LANGUAGE_MAP: { [key: string]: string } = {
+        '.py': 'python',
+        '.js': 'pwa-node',
+        '.ts': 'pwa-node',
+        '.jsx': 'pwa-node',
+        '.tsx': 'pwa-node',
+        '.java': 'java',
+        '.cs': 'coreclr',
+        '.csproj': 'coreclr',
+        '.cpp': 'cppdbg',
+        '.cc': 'cppdbg',
+        '.c': 'cppdbg',
+        '.go': 'go',
+        '.rs': 'lldb',
+        '.php': 'php',
+        '.rb': 'ruby'
+    };
 
     /**
-     * Get or create a debug configuration for the given parameters
+     * Returns either a launch.json configuration name (string) or a minimal
+     * DebugConfiguration stub. Both forms are accepted by
+     * vscode.debug.startDebugging(folder, nameOrConfiguration).
      */
     public async getDebugConfig(
         workingDirectory: string,
         fileFullPath: string,
-        configurationName?: string,
-        testName?: string
-    ): Promise<vscode.DebugConfiguration> {
-        if (!configurationName || configurationName.trim() === '' || configurationName === DebugConfigurationManager.AUTO_LAUNCH_CONFIG) {
-            return this.createDefaultDebugConfig(fileFullPath, workingDirectory, testName);
+        configurationName?: string
+    ): Promise<string | vscode.DebugConfiguration> {
+        // Named launch.json config — let VS Code resolve it itself.
+        if (configurationName &&
+            configurationName.trim() !== '' &&
+            configurationName !== DebugConfigurationManager.AUTO_LAUNCH_CONFIG) {
+            return configurationName;
         }
 
-        try {
-            const launchConfigurations = await this.getLaunchConfigurations(workingDirectory);
-            const namedConfiguration = launchConfigurations.find(config => config?.name === configurationName);
-            if (namedConfiguration) {
-                return {
-                    ...namedConfiguration,
-                    name: `DebugMCP Launch (${namedConfiguration.name || 'Workspace Configuration'})`
-                };
-            }
-        } catch (launchJsonError) {
-            console.log('Could not read or parse launch.json:', launchJsonError);
+        const language = this.detectLanguageFromFilePath(fileFullPath);
+
+        // .NET needs the compiled assembly, not the .cs source file.
+        if (language === 'coreclr') {
+            return await this.createDotNetLaunchConfig(fileFullPath);
         }
 
-        // Fallback: always return a default configuration if nothing else matched
-        return this.createDefaultDebugConfig(fileFullPath, workingDirectory, testName);
-    }
-
-    private async getLaunchConfigurations(workingDirectory: string): Promise<any[]> {
-        const launchJsonPath = vscode.Uri.joinPath(vscode.Uri.file(workingDirectory), '.vscode', 'launch.json');
-        const launchJsonDoc = await vscode.workspace.openTextDocument(launchJsonPath);
-        const launchJsonContent = launchJsonDoc.getText();
-        const launchConfig = jsonc.parse(launchJsonContent);
-
-        if (launchConfig.configurations && Array.isArray(launchConfig.configurations)) {
-            return launchConfig.configurations;
-        }
-
-        return [];
+        // Minimal stub. The language extension's resolveDebugConfiguration
+        // fills in cwd, console, env, stopOnEntry, and other defaults.
+        return {
+            type: language,
+            request: 'launch',
+            name: 'DebugMCP Launch',
+            program: fileFullPath
+        };
     }
 
     public static getAutoLaunchConfigName(): string {
@@ -72,312 +90,100 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
     }
 
     /**
-     * Detect programming language from file extension
+     * Walk up from `startPath` to find the nearest `*.csproj` file.
+     * Stops at the filesystem root.
+     */
+    private async findNearestCsproj(startPath: string): Promise<string | null> {
+        let dir = fs.statSync(startPath).isDirectory() ? startPath : path.dirname(startPath);
+        while (true) {
+            try {
+                const entries = await fs.promises.readdir(dir);
+                const csproj = entries.find(e => e.toLowerCase().endsWith('.csproj'));
+                if (csproj) {
+                    return path.join(dir, csproj);
+                }
+            } catch {
+                // ignore unreadable directories
+            }
+            const parent = path.dirname(dir);
+            if (parent === dir) {
+                return null;
+            }
+            dir = parent;
+        }
+    }
+
+    /**
+     * Locate the built assembly for a .csproj. Looks under
+     * `<projectDir>/bin/{Debug,Release}/<tfm>/<AssemblyName>.dll` and prefers
+     * the most recently modified match.
+     */
+    private async findBuiltAssembly(csprojPath: string): Promise<string | null> {
+        const projectDir = path.dirname(csprojPath);
+        const assemblyName = path.basename(csprojPath, '.csproj');
+        const candidates: { file: string; mtime: number }[] = [];
+
+        for (const config of ['Debug', 'Release']) {
+            const binDir = path.join(projectDir, 'bin', config);
+            if (!fs.existsSync(binDir)) {
+                continue;
+            }
+            for (const tfm of await fs.promises.readdir(binDir)) {
+                const dll = path.join(binDir, tfm, `${assemblyName}.dll`);
+                try {
+                    const stat = await fs.promises.stat(dll);
+                    if (stat.isFile()) {
+                        candidates.push({ file: dll, mtime: stat.mtimeMs });
+                    }
+                } catch {
+                    // missing — try next tfm
+                }
+            }
+        }
+
+        if (candidates.length === 0) {
+            return null;
+        }
+        candidates.sort((a, b) => b.mtime - a.mtime);
+        return candidates[0].file;
+    }
+
+    /**
+     * Build a coreclr launch config pointing at the project's built DLL.
+     * Throws a clear error if the project hasn't been built yet.
+     */
+    private async createDotNetLaunchConfig(fileFullPath: string): Promise<vscode.DebugConfiguration> {
+        const csproj = await this.findNearestCsproj(fileFullPath);
+        if (!csproj) {
+            throw new Error(
+                `Could not locate a .csproj for ${fileFullPath}. ` +
+                `Pass a launch.json configurationName, or place the file inside a .NET project.`
+            );
+        }
+
+        const assembly = await this.findBuiltAssembly(csproj);
+        if (!assembly) {
+            throw new Error(
+                `Could not find a built assembly for ${path.basename(csproj)}. ` +
+                `Run 'dotnet build' first, or pass a launch.json configurationName.`
+            );
+        }
+
+        return {
+            type: 'coreclr',
+            request: 'launch',
+            name: 'DebugMCP .NET Launch',
+            program: assembly,
+            cwd: path.dirname(csproj),
+            stopAtEntry: false
+        };
+    }
+
+    /**
+     * Detect debugger type from file extension.
      */
     public detectLanguageFromFilePath(fileFullPath: string): string {
         const extension = path.extname(fileFullPath).toLowerCase();
-        
-        const languageMap: { [key: string]: string } = {
-            '.py': 'python',
-            '.js': 'node',
-            '.ts': 'node',
-            '.jsx': 'node',
-            '.tsx': 'node',
-            '.java': 'java',
-            '.cs': 'coreclr',
-            '.csproj': 'coreclr',
-            '.cpp': 'cppdbg',
-            '.cc': 'cppdbg',
-            '.c': 'cppdbg',
-            '.go': 'go',
-            '.rs': 'lldb',
-            '.php': 'php',
-            '.rb': 'ruby'
-        };
-
-        return languageMap[extension] || 'python'; // Default to python if unknown
+        return DebugConfigurationManager.LANGUAGE_MAP[extension] || 'python';
     }
-
-    /**
-     * Create a default debug configuration based on file type
-     */
-    private async createDefaultDebugConfig(
-        fileFullPath: string, 
-        workingDirectory: string,
-        testName?: string
-    ): Promise<vscode.DebugConfiguration> {
-        const detectedLanguage = this.detectLanguageFromFilePath(fileFullPath);
-        const cwd = path.dirname(fileFullPath);
-        
-        // Build test-specific configurations based on language
-        if (testName && detectedLanguage !== 'coreclr') {
-            return await this.createTestDebugConfig(detectedLanguage, fileFullPath, cwd, testName);
-        }
-
-        const configs: { [key: string]: vscode.DebugConfiguration } = {
-            python: {
-                type: 'python',
-                request: 'launch',
-                name: 'DebugMCP Python Launch',
-                program: fileFullPath,
-                console: 'integratedTerminal',
-                cwd: cwd,
-                env: {},
-                stopOnEntry: false
-            },
-            node: {
-                type: 'pwa-node',
-                request: 'launch',
-                name: 'DebugMCP Node.js Launch',
-                program: fileFullPath,
-                console: 'integratedTerminal',
-                cwd: cwd,
-                env: {},
-                stopOnEntry: false
-            },
-            java: {
-                type: 'java',
-                request: 'launch',
-                name: 'DebugMCP Java Launch',
-                mainClass: path.basename(fileFullPath, path.extname(fileFullPath)),
-                console: 'integratedTerminal',
-                cwd: cwd
-            },
-            coreclr: {
-                type: 'coreclr',
-                request: 'launch',
-                name: 'DebugMCP .NET Launch',
-                program: fileFullPath,
-                console: 'integratedTerminal',
-                cwd: cwd,
-                stopAtEntry: false
-            },
-            cppdbg: {
-                type: 'cppdbg',
-                request: 'launch',
-                name: 'DebugMCP C++ Launch',
-                program: fileFullPath.replace(/\.(cpp|cc|c)$/, '.exe'),
-                cwd: cwd,
-                console: 'integratedTerminal'
-            },
-            go: {
-                type: 'go',
-                request: 'launch',
-                name: 'DebugMCP Go Launch',
-                mode: 'debug',
-                program: fileFullPath,
-                cwd: cwd
-            }
-        };
-
-        return configs[detectedLanguage] || configs.python; // Fallback to Python if unknown
-    }
-
-    /**
-     * Validate if a workspace has the necessary setup for debugging
-     */
-    public validateWorkspace(workspaceFolder: vscode.WorkspaceFolder): boolean {
-        try {
-            // Basic validation - workspace folder exists
-            return workspaceFolder && workspaceFolder.uri && workspaceFolder.uri.fsPath.length > 0;
-        } catch (error) {
-            console.log('Workspace validation error:', error);
-            return false;
-        }
-    }
-
-    /**
-     * Get available configurations from launch.json
-     */
-    public async getAvailableConfigurations(workspaceFolder: vscode.WorkspaceFolder): Promise<string[]> {
-        try {
-            const launchJsonPath = vscode.Uri.joinPath(workspaceFolder.uri, '.vscode', 'launch.json');
-            const launchJsonDoc = await vscode.workspace.openTextDocument(launchJsonPath);
-            const launchJsonContent = launchJsonDoc.getText();
-            
-            // Parse JSONC (JSON with comments and trailing commas)
-            const launchConfig = jsonc.parse(launchJsonContent);
-            
-            if (launchConfig.configurations && Array.isArray(launchConfig.configurations)) {
-                return launchConfig.configurations.map((config: any) => config.name || 'Unnamed Configuration');
-            }
-            
-            return [];
-        } catch (error) {
-            console.log('Could not read available configurations:', error);
-            return [];
-        }
-    }
-
-    /**
-     * Check if launch.json exists in the workspace
-     */
-    public async hasLaunchJson(workspaceFolder: vscode.WorkspaceFolder): Promise<boolean> {
-        try {
-            const launchJsonPath = vscode.Uri.joinPath(workspaceFolder.uri, '.vscode', 'launch.json');
-            await vscode.workspace.openTextDocument(launchJsonPath);
-            return true;
-        } catch (error) {
-            return false;
-        }
-    }
-
-    /**
-     * Extract the class name from a Python test file
-     * Assumes only one test class per file
-     */
-    private async extractPythonClassName(fileFullPath: string): Promise<string | null> {
-        try {
-            const content = await fs.promises.readFile(fileFullPath, 'utf8');
-            // Match Python class definition: class ClassName or class ClassName(BaseClass)
-            // Looks for classes starting with capital letter (test classes typically follow this pattern)
-            const classMatch = content.match(/class\s+([A-Z][a-zA-Z0-9_]*)/);
-            return classMatch ? classMatch[1] : null;
-        } catch (error) {
-            console.log('Error extracting class name from Python file:', error);
-            return null;
-        }
-    }
-
-    /**
-     * Format Python test name by auto-detecting class name if needed
-     * Supports both class-based tests and standalone test functions
-     */
-    private async formatPythonTestName(fileFullPath: string, testName: string): Promise<string> {
-        const moduleName = path.basename(fileFullPath, '.py');
-        
-        // If testName already contains a dot, assume it's in ClassName.method format
-        if (testName.includes('.')) {
-            return `${moduleName}.${testName}`;
-        }
-        
-        // Otherwise, try to extract the class name from the file
-        const className = await this.extractPythonClassName(fileFullPath);
-        if (className) {
-            // Found a class, format as module.ClassName.testMethod
-            return `${moduleName}.${className}.${testName}`;
-        }
-        
-        // No class found, assume it's a standalone test function
-        return `${moduleName}.${testName}`;
-    }
-
-    /**
-     * Create a debug configuration specifically for running tests
-     */
-    private async createTestDebugConfig(
-        language: string,
-        fileFullPath: string,
-        cwd: string,
-        testName: string
-    ): Promise<vscode.DebugConfiguration> {
-        const fileName = path.basename(fileFullPath);
-
-        switch (language) {
-            case 'python':
-                // Auto-detect class name and format test name appropriately
-                const formattedTestName = await this.formatPythonTestName(fileFullPath, testName);
-                
-                return {
-                    type: 'python',
-                    request: 'launch',
-                    name: `DebugMCP Python Test: ${testName}`,
-                    module: 'unittest',
-                    args: [
-                        formattedTestName,
-                        '-v'
-                    ],
-                    console: 'integratedTerminal',
-                    cwd: cwd,
-                    env: {},
-                    stopOnEntry: false,
-                    justMyCode: false,
-                    purpose: ['debug-test']
-                };
-
-            case 'node':
-                // Support for Jest, Mocha, and other Node.js test frameworks
-                // Try to detect which test framework based on common patterns
-                const isJest = fileName.includes('.test.') || fileName.includes('.spec.');
-                
-                if (isJest) {
-                    // Jest configuration
-                    return {
-                        type: 'pwa-node',
-                        request: 'launch',
-                        name: `DebugMCP Jest Test: ${testName}`,
-                        program: '${workspaceFolder}/node_modules/.bin/jest',
-                        args: [
-                            '--testNamePattern', testName,
-                            '--runInBand',
-                            fileFullPath
-                        ],
-                        console: 'integratedTerminal',
-                        cwd: cwd,
-                        env: {},
-                        stopOnEntry: false
-                    };
-                } else {
-                    // Mocha configuration
-                    return {
-                        type: 'pwa-node',
-                        request: 'launch',
-                        name: `DebugMCP Mocha Test: ${testName}`,
-                        program: '${workspaceFolder}/node_modules/.bin/mocha',
-                        args: [
-                            '--grep', testName,
-                            fileFullPath
-                        ],
-                        console: 'integratedTerminal',
-                        cwd: cwd,
-                        env: {},
-                        stopOnEntry: false
-                    };
-                }
-
-            case 'java':
-                // JUnit test configuration
-                const className = path.basename(fileFullPath, path.extname(fileFullPath));
-                return {
-                    type: 'java',
-                    request: 'launch',
-                    name: `DebugMCP JUnit Test: ${testName}`,
-                    mainClass: className,
-                    args: ['--tests', `${className}.${testName}`],
-                    console: 'integratedTerminal',
-                    cwd: cwd
-                };
-
-            case 'coreclr':
-                // .NET test configuration (supports xUnit, NUnit, MSTest)
-                return {
-                    type: 'coreclr',
-                    request: 'launch',
-                    name: `DebugMCP .NET Test: ${testName}`,
-                    program: 'dotnet',
-                    args: [
-                        'test',
-                        '--filter', `FullyQualifiedName~${testName}`,
-                        '--no-build'
-                    ],
-                    console: 'integratedTerminal',
-                    cwd: cwd,
-                    stopAtEntry: false
-                };
-
-            default:
-                // For unsupported languages, fall back to running the entire file
-                // but include a warning in the name
-                return {
-                    type: language,
-                    request: 'launch',
-                    name: `DebugMCP Launch (test filtering not supported for ${language})`,
-                    program: fileFullPath,
-                    console: 'integratedTerminal',
-                    cwd: cwd,
-                    stopOnEntry: false
-                };
-        }
-    }
-
 }


### PR DESCRIPTION
Fixes (1) **unauthenticated debugger access via 0.0.0.0 bind** and **DNS rebinding via missing Host header validation**, both reported by MSRC against `src/debugMCPServer.ts`, and (2) two bugs in the `start_debugging` flow for VS Code Testing-API runners (notably `dotnet test`) where the tool would hang past a breakpoint hit and past clean test completion.

---

## Part 1 — MSRC: Harden MCP HTTP endpoint

**Background**

The DebugMCP HTTP server exposes powerful, unauthenticated debugger primitives (`evaluate_expression`, `start_debugging`, …). MSRC reported two composable vulnerabilities:

- **603080 — LAN exposure.** `app.listen(this.port, callback)` was called with no host argument, so Node bound to all interfaces (0.0.0.0). Any host on the same Wi‑Fi / co‑working LAN could `POST /mcp` and invoke `evaluate_expression('__import__("os").system(...)')` for RCE on the debuggee, or `start_debugging` against a UNC path.
- **611073 — DNS rebinding → RCE.** Even with a loopback bind, a malicious page on `attacker.example` (short‑TTL DNS flipped to 127.0.0.1) can reach the local server via the victim's browser. The server didn't inspect the `Host` header, so the rebound request hit `start_debugging` with a UNC `fileFullPath` and spawned attacker‑controlled code under the victim's user. PoC video from the finder confirmed it in Firefox.

**Fixes**

- **Bind to loopback by default.** The HTTP server now binds to `127.0.0.1` instead of all interfaces, so it is unreachable from other hosts on the network.
- **Reject non‑loopback `Host` headers.** Requests whose `Host` header doesn't name a loopback address (`localhost`, `127.0.0.1`, `[::1]`, with or without port) are rejected with HTTP 403 before any MCP handler runs — neutralizing DNS‑rebinding attacks even if the bind is later widened.
- **Reject non‑loopback `Origin` headers.** When `Origin` is present (browser‑originated requests), it must also be loopback; absent `Origin` is allowed so non‑browser MCP clients keep working.
- **Explicit opt‑in for LAN exposure.** A new `debugmcp.bindHost` setting lets advanced users widen the bind, with a marketplace warning describing the risk and a startup log warning when the value is non‑loopback.
- **Regression tests.** New security test suite covers the loopback / IPv6 / port‑suffix / attacker / LAN cases for the header validators, asserts the server refuses TCP on a non‑loopback interface, and asserts live `POST /mcp` requests with attacker `Host` / `Origin` headers receive 403.
- **Documented security model.** README now describes the loopback‑only default, the opt‑in `bindHost`, and the `Host`/`Origin` allow‑list, so the documented contract matches the implementation.

**Manual repro against the fixed build**

Rebinding-style request — now rejected:
```
curl -i -X POST "http://127.0.0.1:3001/mcp" \
  -H "Host: attacker.example" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
→ HTTP/1.1 403 Forbidden
{"jsonrpc":"2.0","error":{"code":-32000,"message":"Forbidden: Host header is not a loopback address"},"id":null}
```

LAN-style probe — connection now refused:
```
nmap -p 3001 <your-LAN-IP>
→ 3001/tcp closed
```

---

## Part 2 — Fix `start_debugging` hangs for Testing-API runners (e.g. `dotnet test`)

**Background**

When `start_debugging` is called with a `testName`, the handler routes through VS Code's Testing API (`testing.debugAtCursor`) so language extensions can manage runner-specific orchestration (e.g. `dotnet test --filter <name>` spawning a `testhost.dll` child process for xUnit/NUnit/MSTest). Two bugs were observed against a .NET xUnit project (`Calculator.Tests`):

1. **Hang past breakpoint hit.** `debugTestAtCursor` `await`ed `vscode.commands.executeCommand('testing.debugAtCursor')`, but that command's promise resolves only when the test run *completes*, not when the debug session starts. When the test paused on a breakpoint, the `await` blocked the handler forever — the `readyPromise` had already resolved `'stopped'` but the handler never reached `await readyPromise`. The MCP tool only returned when something external (e.g. the next MCP request) caused the run to wrap up.
2. **Hang past clean completion.** When the test ran to completion without pausing, `onDidTerminateDebugSession` did not reliably fire for both the parent and `testhost` child sessions in time, so `waitForDebugSessionReady` ran out the configured timeout (default 180s) even though the test was clearly done.

**Fixes**

- **Decouple readiness from test-run completion.** `IDebuggingExecutor.debugTestAtCursor` now returns `{ started, runComplete }`. The implementation no longer `await`s `testing.debugAtCursor`; it surfaces the command's promise so the caller can use it as an independent "test run finished" signal. Dispatch errors are still surfaced (logged) via `.catch`.
- **Race `readyPromise` against `runComplete` in the handler.** `handleStartDebugging` now does `Promise.race([readyPromise, runComplete.then(() => 'terminated')])` for the test path. A breakpoint hit returns immediately as `'stopped'`; a clean run returns immediately as `'terminated'`. The configured timeout is no longer a wait floor for either case.
- **Surface `coreclr` no-build / missing-assembly errors clearly.** The launch-config branch already threw a descriptive error when no built DLL was found; this PR's tests guard the contract.

**Regression matrix tests — `src/test/startDebuggingMatrix.test.ts`**

44 new fully‑mocked tests covering both code paths × four scenarios × seven languages. The mocks use `deferred<T>()` so each test deterministically controls when `readyPromise` and `runComplete` settle — no timers, no flakes.

| Scenario | Launch path (no `testName`) | Test path (with `testName`) |
|---|---|---|
| **pause-hit** | `readyPromise → 'stopped'` → "stopped at breakpoint" | breakpoint wins race against pending `runComplete` → "stopped at breakpoint" (guards bug #1) |
| **clean-run** | `readyPromise → 'terminated'` → "ran to completion" | `runComplete` wins against a *never-settling* `readyPromise` → "ran to completion" (guards bug #2) |
| **launch-error** | `startDebugging → false` → "Failed to start" | `debugTestAtCursor` throws → propagates "Could not locate test" |
| **no-build** | `getDebugConfig` throws → propagates "Could not find a built assembly" (C# only) | — |

Languages covered: Python, JavaScript, TypeScript, Java, C#, C++, Go. Plus one race tie-breaker test ensuring a `runComplete` resolution after `readyPromise → 'stopped'` cannot retroactively change the outcome.

**Test housekeeping**

Removed stale compiled artifacts under `out/test/` that had no corresponding `.ts` source (`debugConfigurationManager.test.js` and the `e2e/` folder) — they referenced API surfaces removed in earlier refactors and accounted for all 20 previously failing tests. Full suite now: **66 passing, 0 failing.**

---

## Validation

- `npm run compile` ✅
- `npm run lint` ✅
- `npm test` ✅ — 66 passing / 0 failing (after Inno Setup mutex from a stuck `CodeSetup-stable-*` installer was cleared)
