### PR TITLE
fix: register GET/DELETE /mcp for Streamable HTTP (Inspector, Rider, and other clients)

### DIFF
--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -343,6 +343,20 @@ export class DebugMCPServer {
                 next(error);
             });
 
+            // Stateless server: no SSE on GET - MCP spec requires explicit 405 (not 404).
+            const methodNotAllowedHandler = (_req: any, res: any) => {
+                res.status(405).json({
+                    jsonrpc: '2.0',
+                    error: {
+                        code: -32000,
+                        message: 'Method not allowed. Use POST /mcp.'
+                    },
+                    id: null
+                });
+            };
+            app.get('/mcp', methodNotAllowedHandler);
+            app.delete('/mcp', methodNotAllowedHandler);
+
             // Streamable HTTP endpoint — handles MCP protocol messages
             app.post('/mcp', async (req: any, res: any) => {
                 logger.info('New MCP request received');
@@ -367,28 +381,6 @@ export class DebugMCPServer {
                                 code: -32603,
                                 message: 'Internal MCP server error'
                             }
-                        });
-
-                        app.get('/mcp', async (_req: any, res: any) => {
-                            res.status(405).json({
-                                jsonrpc: '2.0',
-                                error: {
-                                    code: -32000,
-                                    message: 'Method not allowed. Use POST /mcp.'
-                                },
-                                id: null
-                            });
-                        });
-
-                        app.delete('/mcp', async (_req: any, res: any) => {
-                            res.status(405).json({
-                                jsonrpc: '2.0',
-                                error: {
-                                    code: -32000,
-                                    message: 'Method not allowed. Use POST /mcp.'
-                                },
-                                id: null
-                            });
                         });
                     }
                 }


### PR DESCRIPTION
## Problem

DebugMCP exposes a Streamable HTTP endpoint at `POST /mcp` (default port 3001).
Several MCP clients perform an initial **`GET /mcp`** during connection to check
whether the server offers a Server-Sent Events (SSE) stream for server-to-client
messages.

According to the [MCP Streamable HTTP transport spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports),
the endpoint must support both POST and GET. If the server is stateless and does
not provide SSE, it **must** respond to GET with **HTTP 405 Method Not Allowed**
(not 404).

In the current implementation, `app.get('/mcp')` and `app.delete('/mcp')` are
registered only inside the `catch` block of the `POST /mcp` handler. Until a POST
request fails, **no GET route exists**, so clients receive **HTTP 404**.

### Affected clients (confirmed in practice)

| Client | Symptom |
|--------|---------|
| **MCP Inspector** (`@modelcontextprotocol/inspector`, Streamable HTTP) | `Connect failed (HTTP): Expected status code 200 but was 404` on `GET http://localhost:3001/mcp` |
| **JetBrains Rider** (built-in MCP / `mcp-rider-tools`, Streamable HTTP to external servers) | Same connect failure when adding DebugMCP as an HTTP MCP server at `http://localhost:3001/mcp` |
| **Other Streamable HTTP MCP clients** (e.g. Cursor, VS Code MCP, Claude Desktop with `streamableHttp`) | Same pattern: GET probe during handshake before POST `initialize` |

`POST /mcp` with a valid `initialize` request works; the failure is specific to
the missing or late-registered GET handler.

## Fix

- Register `GET /mcp` and `DELETE /mcp` at server startup (before `POST /mcp`).
- Return **405** with a JSON-RPC-style error body for stateless mode (no SSE).
- Remove duplicate route registration from the `POST` `catch` block.

## How to verify

1. Build/run the extension from this branch.
2. Ensure DebugMCP is listening on port 3001 (default `debugmcp.serverPort`).

```bash
# Must return 405, not 404
curl -i -X GET http://localhost:3001/mcp \
  -H "Accept: application/json, text/event-stream"

# Must return 200 with initialize result
curl -i -X POST http://localhost:3001/mcp \
  -H "Accept: application/json, text/event-stream" \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
```

3. **MCP Inspector**: Transport = Streamable HTTP, URL = `http://localhost:3001/mcp`,
   headers `Accept: application/json, text/event-stream`, `Content-Type: application/json` → connect succeeds.

4. **JetBrains Rider**: Settings → Tools → MCP Servers — add HTTP server
   `http://localhost:3001/mcp` with Streamable HTTP → tools/resources list loads.

## Notes

- Legacy `GET /sse` remains **410 Gone** (deprecated SSE endpoint); this change only fixes `/mcp`.
- No session/SSE support is added; clients that accept 405 on GET continue with POST-only communication.
