### PR TITLE
Prevent setup from overwriting malformed JSON configuration files

### DIFF
--- a/docs/architecture/agentConfigurationManager.md
+++ b/docs/architecture/agentConfigurationManager.md
@@ -13,6 +13,7 @@ For AI agents to use DebugMCP, they need MCP server configuration in their setti
 - Detect supported AI agents and their config file paths
 - Show post-install popup for agent selection
 - Write MCP server configuration to agent settings files
+- Preserve existing JSON configuration files when they cannot be parsed
 - Handle cross-platform config path differences (Windows, macOS, Linux)
 - Track whether onboarding popup has been shown
 

--- a/docs/architecture/agentConfigurationManager.md
+++ b/docs/architecture/agentConfigurationManager.md
@@ -17,6 +17,10 @@ For AI agents to use DebugMCP, they need MCP server configuration in their setti
 - Handle cross-platform config path differences (Windows, macOS, Linux)
 - Track whether onboarding popup has been shown
 
+When an existing JSON configuration is malformed, setup leaves it unchanged and offers to
+open the file. The error also directs users to rerun **DebugMCP: Show Agent Selection
+Popup** from the Command Palette after correcting the JSON.
+
 ## Supported Agents
 
 | Agent | Config File | MCP Field |

--- a/src/test/agentConfigurationManager.test.ts
+++ b/src/test/agentConfigurationManager.test.ts
@@ -1,7 +1,35 @@
 // Copyright (c) Microsoft Corporation.
 
 import * as assert from 'assert';
-import { upsertCodexDebugMCPConfig } from '../utils/agentConfigurationManager';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    upsertCodexDebugMCPConfig,
+    upsertJsonDebugMCPConfigFile
+} from '../utils/agentConfigurationManager';
+
+suite('AgentConfigurationManager JSON configuration', () => {
+    test('upsertJsonDebugMCPConfigFile should preserve an existing file if it contains malformed JSON', async () => {
+        const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'debugmcp-agent-config-'));
+        const configPath = path.join(tempDir, 'mcp.json');
+        const malformedConfig = '{\n  "servers": {\n    "other": true,\n';
+        await fs.promises.writeFile(configPath, malformedConfig, 'utf8');
+
+        try {
+            await assert.rejects(
+                upsertJsonDebugMCPConfigFile(configPath, 'servers', {
+                    type: 'streamableHttp',
+                    url: 'http://localhost:3001/mcp'
+                }),
+                SyntaxError
+            );
+            assert.strictEqual(await fs.promises.readFile(configPath, 'utf8'), malformedConfig);
+        } finally {
+            await fs.promises.rm(tempDir, { recursive: true, force: true });
+        }
+    });
+});
 
 suite('AgentConfigurationManager Codex TOML configuration', () => {
     const mcpServerUrl = 'http://localhost:3001/mcp';

--- a/src/utils/agentConfigurationManager.ts
+++ b/src/utils/agentConfigurationManager.ts
@@ -33,6 +33,26 @@ export interface MCPServerConfig {
     tools?: string[];
 }
 
+export async function upsertJsonDebugMCPConfigFile(
+    configPath: string,
+    fieldName: string,
+    debugMCPConfig: MCPServerConfig
+): Promise<void> {
+    let config: any = {};
+
+    if (fs.existsSync(configPath)) {
+        const configContent = await fs.promises.readFile(configPath, 'utf8');
+        config = JSON.parse(configContent);
+    }
+
+    if (!config[fieldName]) {
+        config[fieldName] = {};
+    }
+
+    config[fieldName].debugmcp = debugMCPConfig;
+    await fs.promises.writeFile(configPath, JSON.stringify(config, null, 2), 'utf8');
+}
+
 export function upsertCodexDebugMCPConfig(configContent: string, mcpServerUrl: string): string {
     const normalizedConfigContent = configContent.replace(/\r\n/g, '\n');
     const lines = normalizedConfigContent.split('\n');
@@ -528,34 +548,31 @@ export class AgentConfigurationManager {
                 return { success: true, skillPath };
             }
 
-            let config: any = {};
-            
-            // Read existing config if it exists
-            if (fs.existsSync(agent.configPath)) {
-                const configContent = await fs.promises.readFile(agent.configPath, 'utf8');
-                try {
-                    config = JSON.parse(configContent);
-                } catch (parseError) {
-                    console.warn(`Failed to parse existing config for ${agent.name}, creating new config`);
-                    config = {};
-                }
-            }
-
-            // Ensure the correct MCP servers object exists for this agent
             const fieldName = agent.mcpServerFieldName;
-            if (!config[fieldName]) {
-                config[fieldName] = {};
+            try {
+                await upsertJsonDebugMCPConfigFile(
+                    agent.configPath,
+                    fieldName,
+                    this.getDebugMCPConfig(agent)
+                );
+            } catch (error) {
+                if (!(error instanceof SyntaxError)) {
+                    throw error;
+                }
+
+                console.error(`Failed to parse existing config for ${agent.name}:`, error);
+                const openConfigButton = 'Open Config';
+                const result = await vscode.window.showErrorMessage(
+                    `Failed to configure DebugMCP for ${agent.displayName}: the existing configuration contains invalid JSON.`,
+                    openConfigButton
+                );
+
+                if (result === openConfigButton) {
+                    await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(agent.configPath));
+                }
+
+                return { success: false, skillPath: null };
             }
-
-            // Add or update DebugMCP configuration with current settings
-            config[fieldName].debugmcp = this.getDebugMCPConfig(agent);
-
-            // Write the updated config back to file
-            await fs.promises.writeFile(
-                agent.configPath, 
-                JSON.stringify(config, null, 2), 
-                'utf8'
-            );
 
             console.log(`Successfully added DebugMCP configuration to ${agent.name}`);
             const skillPath = await this.installDebugMCPSkill();

--- a/src/utils/agentConfigurationManager.ts
+++ b/src/utils/agentConfigurationManager.ts
@@ -563,7 +563,8 @@ export class AgentConfigurationManager {
                 console.error(`Failed to parse existing config for ${agent.name}:`, error);
                 const openConfigButton = 'Open Config';
                 const result = await vscode.window.showErrorMessage(
-                    `Failed to configure DebugMCP for ${agent.displayName}: the existing configuration contains invalid JSON.`,
+                    `Failed to configure DebugMCP for ${agent.displayName}: the existing configuration contains invalid JSON. ` +
+                    'Fix the JSON, then run "DebugMCP: Show Agent Selection Popup" from the Command Palette to retry setup.',
                     openConfigButton
                 );
 


### PR DESCRIPTION
## Summary

- stop configuration when an existing JSON file cannot be parsed
- show an error with an Open Config action
- preserve the existing file byte-for-byte and skip skill installation
- document the data-safety behavior

## Testing

- npm run check-types
- npm run lint
- npm test (97 passing)