### PR TITLE
Remember when the setup picker is dismissed

### DIFF
--- a/docs/architecture/agentConfigurationManager.md
+++ b/docs/architecture/agentConfigurationManager.md
@@ -71,7 +71,7 @@ url = "http://localhost:3001/mcp"
 
 ### Popup State
 
-Uses VS Code's `globalState` to track whether the onboarding popup has been shown, preventing repeated prompts on every activation.
+Uses VS Code's `globalState` to track whether the onboarding popup has been shown or dismissed, preventing repeated prompts on every activation. Users can still reopen setup from the Command Palette.
 
 ### Skill delivery — standard skills directories
 
@@ -100,7 +100,7 @@ This fixes issue #105: earlier builds copied the skill next to each agent's conf
 3. If not, display multi-select dialog with supported agents
 4. For each selected agent, write/update config file
 5. Show success message with option to open config file
-6. Mark popup as shown
+6. Mark popup as shown after it is accepted or dismissed
 
 The bundled `debug-live` skill is installed into the standard skills directories (`~/.agents/skills/`, plus `~/.copilot/skills/` when present) during step 4, so every skills-compatible harness discovers it from one shared location.
 

--- a/src/utils/agentConfigurationManager.ts
+++ b/src/utils/agentConfigurationManager.ts
@@ -589,7 +589,10 @@ export class AgentConfigurationManager {
         quickPick.canSelectMany = true;
         quickPick.ignoreFocusOut = true;
 
+        let accepted = false;
+
         quickPick.onDidAccept(async () => {
+            accepted = true;
             const selectedItems = quickPick.selectedItems;
             quickPick.hide();
 
@@ -610,7 +613,12 @@ export class AgentConfigurationManager {
             await this.context.globalState.update(this.POPUP_SHOWN_KEY, true);
         });
 
-        quickPick.onDidHide(() => quickPick.dispose());
+        quickPick.onDidHide(async () => {
+            quickPick.dispose();
+            if (!accepted) {
+                await this.context.globalState.update(this.POPUP_SHOWN_KEY, true);
+            }
+        });
         quickPick.show();
     }
 


### PR DESCRIPTION
## Summary

- remember when the first-run setup picker is dismissed without a selection
- distinguish dismissal from the existing accepted flow
- keep manual setup available through the Command Palette
- document the updated first-run behavior

## Testing

- npm run check-types
- npm run lint
- npm test (96 passing)