### PR TITLE
feat: add noWait parameter to start_debugging and continue_execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,47 @@ The `docs/` folder contains two types of documentation:
 | `agent-resources/troubleshooting/*.md` | Language-specific debugging tips (Python, JavaScript, Java, C#) |
 
 These resource files are loaded by `DebugMCPServer` and exposed as MCP resources that AI agents can read to learn how to use the debugging tools effectively.
+
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **DebugMCP** (1057 symbols, 2730 relationships, 82 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/DebugMCP/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/DebugMCP/clusters` | All functional areas |
+| `gitnexus://repo/DebugMCP/processes` | All execution flows |
+| `gitnexus://repo/DebugMCP/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+<!-- gitnexus:start -->
+# GitNexus — Code Intelligence
+
+This project is indexed by GitNexus as **DebugMCP** (1057 symbols, 2730 relationships, 82 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+
+> If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
+
+## Always Do
+
+- **MUST run impact analysis before editing any symbol.** Before modifying a function, class, or method, run `gitnexus_impact({target: "symbolName", direction: "upstream"})` and report the blast radius (direct callers, affected processes, risk level) to the user.
+- **MUST run `gitnexus_detect_changes()` before committing** to verify your changes only affect expected symbols and execution flows.
+- **MUST warn the user** if impact analysis returns HIGH or CRITICAL risk before proceeding with edits.
+- When exploring unfamiliar code, use `gitnexus_query({query: "concept"})` to find execution flows instead of grepping. It returns process-grouped results ranked by relevance.
+- When you need full context on a specific symbol — callers, callees, which execution flows it participates in — use `gitnexus_context({name: "symbolName"})`.
+
+## Never Do
+
+- NEVER edit a function, class, or method without first running `gitnexus_impact` on it.
+- NEVER ignore HIGH or CRITICAL risk warnings from impact analysis.
+- NEVER rename symbols with find-and-replace — use `gitnexus_rename` which understands the call graph.
+- NEVER commit changes without running `gitnexus_detect_changes()` to check affected scope.
+
+## Resources
+
+| Resource | Use for |
+|----------|---------|
+| `gitnexus://repo/DebugMCP/context` | Codebase overview, check index freshness |
+| `gitnexus://repo/DebugMCP/clusters` | All functional areas |
+| `gitnexus://repo/DebugMCP/processes` | All execution flows |
+| `gitnexus://repo/DebugMCP/process/{name}` | Step-by-step execution trace |
+
+## CLI
+
+| Task | Read this skill file |
+|------|---------------------|
+| Understand architecture / "How does X work?" | `.claude/skills/gitnexus/gitnexus-exploring/SKILL.md` |
+| Blast radius / "What breaks if I change X?" | `.claude/skills/gitnexus/gitnexus-impact-analysis/SKILL.md` |
+| Trace bugs / "Why is X failing?" | `.claude/skills/gitnexus/gitnexus-debugging/SKILL.md` |
+| Rename / extract / split / refactor | `.claude/skills/gitnexus/gitnexus-refactoring/SKILL.md` |
+| Tools, resources, schema reference | `.claude/skills/gitnexus/gitnexus-guide/SKILL.md` |
+| Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
+
+<!-- gitnexus:end -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -942,7 +942,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1201,7 +1200,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2002,7 +2000,6 @@
       "integrity": "sha512-20MV9SUdeN6Jd84xESsKhRly+/vxI+hwvpBMA93s+9dAcjdCuCojn4IqUGS3lvVaqjVYGYHSRMCpeFtF2rQYxQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2233,7 +2230,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2638,7 +2634,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4222,7 +4217,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4298,7 +4292,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4614,7 +4607,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/controlServer.ts
+++ b/src/controlServer.ts
@@ -90,7 +90,7 @@ export class ControlServer {
 			case 'handleStepOut':
 				return this.handler.handleStepOut();
 			case 'handleContinue':
-				return this.handler.handleContinue();
+				return this.handler.handleContinue(args);
 			case 'handlePause':
 				return this.handler.handlePause();
 			case 'handleRestart':

--- a/src/controlServer.ts
+++ b/src/controlServer.ts
@@ -109,6 +109,8 @@ export class ControlServer {
 				return this.handler.handleGetVariables(args);
 			case 'handleEvaluateExpression':
 				return this.handler.handleEvaluateExpression(args);
+			case 'handleGetDebugState':
+				return this.handler.handleGetDebugState();
 			default:
 				return Promise.reject(new Error(`Unknown control op: ${op}`));
 		}

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -220,8 +220,11 @@ export class DebugMCPServer {
                     'Optional debug configuration name from launch.json. ' +
                     'If omitted, DebugMCP uses its default generated configuration.'
                 ),
+                noWait: z.boolean().optional().describe(
+                    'If true, returns immediately after starting instead of waiting for a breakpoint.'
+                ),
             },
-        }, async (args: { fileFullPath: string; workingDirectory: string; testName?: string; configurationName?: string }) =>
+        }, async (args: { fileFullPath: string; workingDirectory: string; testName?: string; configurationName?: string; noWait?: boolean }) =>
             this.runTool('start_debugging', () => debuggingHandler.handleStartDebugging(args)));
 
         // Stop debugging tool
@@ -247,7 +250,10 @@ export class DebugMCPServer {
         // Continue execution tool
         server.registerTool('continue_execution', {
             description: 'Resume program execution until the next breakpoint is hit or the program completes.',
-        }, async () => this.runTool('continue_execution', () => debuggingHandler.handleContinue()));
+            inputSchema: {
+                noWait: z.boolean().optional().describe('If true, returns immediately instead of waiting for the next breakpoint.'),
+            },
+        }, async (args: { noWait?: boolean } = {}) => this.runTool('continue_execution', () => debuggingHandler.handleContinue(args)));
 
         // Pause execution tool
         server.registerTool('pause_execution', {

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -232,6 +232,11 @@ export class DebugMCPServer {
             description: 'Stop the current debug session',
         }, async () => this.runTool('stop_debugging', () => debuggingHandler.handleStopDebugging()));
 
+        // Get debug state tool
+        server.registerTool('get_debug_state', {
+            description: 'Get the current state of the debug session (running, paused, or inactive), including current breakpoint location and pause reason if paused.',
+        }, async () => this.runTool('get_debug_state', () => debuggingHandler.handleGetDebugState()));
+
         // Step over tool
         server.registerTool('step_over', {
             description: 'Execute the current line of code without diving into it.',

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -25,6 +25,7 @@ export interface IDebuggingHandler {
     handleListBreakpoints(): Promise<string>;
     handleGetVariables(args: { scope?: 'local' | 'global' | 'all' }): Promise<string>;
     handleEvaluateExpression(args: { expression: string }): Promise<string>;
+    handleGetDebugState(): Promise<string>;
 }
 
 /**
@@ -514,7 +515,19 @@ export class DebuggingHandler implements IDebuggingHandler {
     }
 
     /**
-     * Get current debug state
+     * Get current debug state as string
+     */
+    public async handleGetDebugState(): Promise<string> {
+        try {
+            const state = await this.executor.getCurrentDebugState(this.numNextLines);
+            return state.toString();
+        } catch (error) {
+            throw new Error(`Error getting debug state: ${error}`);
+        }
+    }
+
+    /**
+     * Get current debug state object
      */
     public async getCurrentDebugState(): Promise<DebugState> {
         return await this.executor.getCurrentDebugState(this.numNextLines);

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -10,12 +10,12 @@ import { logger } from './utils/logger';
  * Interface for debugging handler operations
  */
 export interface IDebuggingHandler {
-    handleStartDebugging(args: { fileFullPath: string; workingDirectory: string; testName?: string; configurationName?: string }): Promise<string>;
+    handleStartDebugging(args: { fileFullPath: string; workingDirectory: string; testName?: string; configurationName?: string; noWait?: boolean }): Promise<string>;
     handleStopDebugging(): Promise<string>;
     handleStepOver(): Promise<string>;
     handleStepInto(): Promise<string>;
     handleStepOut(): Promise<string>;
-    handleContinue(): Promise<string>;
+    handleContinue(args?: { noWait?: boolean }): Promise<string>;
     handlePause(): Promise<string>;
     handleRestart(): Promise<string>;
     handleAddBreakpoint(args: { fileFullPath: string; line: number; condition?: string }): Promise<string>;
@@ -51,8 +51,9 @@ export class DebuggingHandler implements IDebuggingHandler {
         workingDirectory: string;
         testName?: string;
         configurationName?: string;
+        noWait?: boolean;
     }): Promise<string> {
-        const { fileFullPath, workingDirectory, testName, configurationName } = args;
+        const { fileFullPath, workingDirectory, testName, configurationName, noWait } = args;
         const hasExplicitConfig = !!configurationName &&
             configurationName.trim() !== '' &&
             configurationName !== DebugConfigurationManager.getAutoLaunchConfigName();
@@ -90,6 +91,10 @@ export class DebuggingHandler implements IDebuggingHandler {
             }
 
             if (started) {
+                if (noWait) {
+                    return `Debug session started (noWait=true) for: ${fileFullPath} using ${configDescription}. The session is running in the background.`;
+                }
+
                 // Race the readiness signal against the test run completion. For .NET
                 // (and any runner where onDidTerminateDebugSession doesn't fire
                 // reliably for parent/child sessions), the test-run-complete signal
@@ -232,7 +237,7 @@ export class DebuggingHandler implements IDebuggingHandler {
     /**
      * Continue execution
      */
-    public async handleContinue(): Promise<string> {
+    public async handleContinue(args?: { noWait?: boolean }): Promise<string> {
         try {
             if (!(await this.executor.hasActiveSession())) {
                 throw new Error('Debug session is not ready. Please wait for initialization to complete.');
@@ -243,6 +248,10 @@ export class DebuggingHandler implements IDebuggingHandler {
 
             await this.executor.continue();
             
+            if (args?.noWait) {
+                return "Execution continued (noWait=true). The program is running in the background.";
+            }
+
             // Wait for debugger state to change
             const afterState = await this.waitForStateChange(beforeState);
             

--- a/src/routingDebuggingHandler.ts
+++ b/src/routingDebuggingHandler.ts
@@ -168,6 +168,7 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 		workingDirectory: string;
 		testName?: string;
 		configurationName?: string;
+		noWait?: boolean;
 	}): Promise<string> {
 		return this.forward('handleStartDebugging', args, args.workingDirectory || args.fileFullPath);
 	}
@@ -188,8 +189,8 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 		return this.forward('handleStepOut', {});
 	}
 
-	public handleContinue(): Promise<string> {
-		return this.forward('handleContinue', {});
+	public handleContinue(args?: { noWait?: boolean }): Promise<string> {
+		return this.forward('handleContinue', args || {});
 	}
 
 	public handlePause(): Promise<string> {

--- a/src/routingDebuggingHandler.ts
+++ b/src/routingDebuggingHandler.ts
@@ -228,4 +228,8 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 	public handleEvaluateExpression(args: { expression: string }): Promise<string> {
 		return this.forward('handleEvaluateExpression', args);
 	}
+
+	public handleGetDebugState(): Promise<string> {
+		return this.forward('handleGetDebugState', {});
+	}
 }

--- a/src/test/routing.test.ts
+++ b/src/test/routing.test.ts
@@ -34,6 +34,7 @@ class RecordingHandler implements IDebuggingHandler {
 	handleListBreakpoints() { return this.record('listBp', {}); }
 	handleGetVariables(args: any) { return this.record('vars', args); }
 	handleEvaluateExpression(args: any) { return this.record('eval', args); }
+	handleGetDebugState() { return this.record('getDebugState', {}); }
 }
 
 suite('Multi-window routing', () => {


### PR DESCRIPTION
## Description

Historically, DebugMCP's \start_debugging\ and \continue_execution\ calls blocked *synchronously* until a breakpoint was hit. If an AI agent invoked \start_debugging\ *before* informing the user in text, the turn blocked in a tool-call wait state, preventing the user from receiving the prompt instructions.

This PR natively updates \microsoft/DebugMCP\ to support \
oWait: true\.
The agent can now call \start_debugging(noWait: true)\ to arm the debugger in the background and **immediately** get control back to output instructions to the user.
The human user can then safely interact with the UI at their own pace. Once the breakpoint is reached, the IDE natively pauses execution and the agent can evaluate expressions.