### PR TITLE
Add reusable debug-live trigger evaluation

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 .github/**
 src/**
+scripts/**
 out/**
 node_modules/**
 docs/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debugmcpextension",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debugmcpextension",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "debugmcpextension",
   "displayName": "DebugMCP — Agentic Debugging for VS Code, Cursor & More",
   "description": "Your AI agent debugs for you — right inside VS Code, Cursor & other VS Code-based editors. Let Copilot, Cline, Cursor, Codex & any MCP agent set breakpoints, step through code, and inspect variables live instead of guessing from logs.",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "publisher": "ozzafar",
   "author": {
     "name": "Oz Zafar",
@@ -123,7 +123,8 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run bundle && npm run lint",
     "lint": "eslint src",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "test:skill-trigger-agent": "node scripts/test-debug-skill-trigger.js"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",

--- a/scripts/test-debug-skill-trigger.js
+++ b/scripts/test-debug-skill-trigger.js
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+
+const assert = require('node:assert');
+const childProcess = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const defaultPrompt =
+	'A test fails only at runtime. The user object unexpectedly becomes null inside processOrder';
+const prompt = process.argv.slice(2).join(' ') || defaultPrompt;
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'debugmcp-skill-eval-'));
+const worktreePath = path.join(tempRoot, 'worktree');
+
+function run(command, args, options = {}) {
+	const result = childProcess.spawnSync(command, args, {
+		cwd: repoRoot,
+		encoding: 'utf8',
+		maxBuffer: 20 * 1024 * 1024,
+		...options
+	});
+
+	if (result.error) {
+		throw result.error;
+	}
+	if (result.status !== 0) {
+		throw new Error(
+			`${command} ${args.join(' ')} failed with exit code ${result.status}\n` +
+			`${result.stderr || result.stdout}`
+		);
+	}
+
+	return result.stdout;
+}
+
+function getCopilotInvocation() {
+	if (process.platform !== 'win32') {
+		return { command: 'copilot', args: [] };
+	}
+
+	const copilotPath = run(
+		'powershell.exe',
+		['-NoProfile', '-NonInteractive', '-Command', '(Get-Command copilot -ErrorAction Stop).Source']
+	).trim();
+	return {
+		command: 'powershell.exe',
+		args: ['-NoProfile', '-NonInteractive', '-File', copilotPath]
+	};
+}
+
+function parseEvents(output) {
+	return output
+		.split(/\r?\n/)
+		.filter(Boolean)
+		.flatMap(line => {
+			try {
+				return [JSON.parse(line)];
+			} catch {
+				return [];
+			}
+		});
+}
+
+try {
+	run('git', ['worktree', 'add', '--detach', worktreePath, 'HEAD']);
+
+	const sourceSkillPath = path.join(repoRoot, 'skills', 'debug-live');
+	const projectSkillPath = path.join(worktreePath, '.agents', 'skills', 'debug-live');
+	fs.mkdirSync(path.dirname(projectSkillPath), { recursive: true });
+	fs.cpSync(sourceSkillPath, projectSkillPath, { recursive: true });
+
+	const copilot = getCopilotInvocation();
+	const output = run(copilot.command, [...copilot.args,
+		'-C', worktreePath,
+		'-p', prompt,
+		'--output-format', 'json',
+		'--allow-all-tools',
+		'--no-custom-instructions',
+		'--no-remote',
+		'--no-remote-export',
+		'--log-level', 'none'
+	], { cwd: worktreePath });
+
+	const events = parseEvents(output);
+	const toolCalls = events
+		.filter(event => event.type === 'tool.execution_start')
+		.map(event => event.data);
+	const firstToolCall = toolCalls[0];
+
+	assert.ok(firstToolCall, 'Copilot did not execute any tool');
+	assert.strictEqual(
+		firstToolCall.toolName,
+		'skill',
+		`Expected the first tool to be skill, got ${firstToolCall.toolName}`
+	);
+	assert.strictEqual(
+		firstToolCall.arguments?.skill,
+		'debug-live',
+		`Expected debug-live, got ${JSON.stringify(firstToolCall.arguments)}`
+	);
+
+	console.log(`Prompt: ${prompt}`);
+	console.log('PASS: Copilot invoked debug-live as its first tool call.');
+	console.log(`Next tool: ${toolCalls[1]?.toolName ?? '<none>'}`);
+} finally {
+	childProcess.spawnSync(
+		'git',
+		['worktree', 'remove', '--force', worktreePath],
+		{ cwd: repoRoot, encoding: 'utf8' }
+	);
+	childProcess.spawnSync('git', ['worktree', 'prune'], { cwd: repoRoot, encoding: 'utf8' });
+	fs.rmSync(tempRoot, { recursive: true, force: true });
+}

--- a/skills/debug-live/README.md
+++ b/skills/debug-live/README.md
@@ -61,3 +61,16 @@ You also need:
 2. The language extension for whatever you're debugging (Python, C# Dev Kit, Java
    Extension Pack, etc. — see the per-language reference for specifics).
 3. Your AI agent runtime configured to connect to that MCP endpoint.
+
+## Live trigger evaluation
+
+Run `npm run test:skill-trigger-agent` to launch a real Copilot CLI session and verify
+from its JSON tool events that `debug-live` is the first tool invoked for the default
+runtime-null scenario. This is an opt-in model evaluation: it requires an authenticated
+Copilot CLI, consumes AI credits, and may be nondeterministic.
+
+Pass a different prompt after `--`:
+
+```text
+npm run test:skill-trigger-agent -- "A runtime test hangs while processing a request"
+```

--- a/src/test/debugSkillGuidance.test.ts
+++ b/src/test/debugSkillGuidance.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import { suite, test } from 'mocha';
+
+suite('debug-live skill guidance', () => {
+    const skillPath = path.resolve(__dirname, '..', '..', 'skills', 'debug-live', 'SKILL.md');
+    const serverPath = path.resolve(__dirname, '..', '..', 'src', 'debugMCPServer.ts');
+    const skill = fs.readFileSync(skillPath, 'utf8');
+    const serverSource = fs.readFileSync(serverPath, 'utf8');
+    const description = skill.match(/^description:\s*(.+)$/m)?.[1] ?? '';
+
+    test('skill metadata covers common runtime investigation triggers', () => {
+        for (const trigger of [
+            'runtime bugs',
+            'failing tests',
+            'exceptions',
+            'crashes',
+            'hangs',
+            'wrong/null values',
+            'unexpected output'
+        ]) {
+            assert.ok(description.includes(trigger), `Missing skill trigger: ${trigger}`);
+        }
+    });
+
+    test('skill metadata prefers live debugging over temporary source logging', () => {
+        assert.match(description, /when live inspection is practical/i);
+        assert.match(description, /instead of modifying source code with temporary logs, print statements, or console output/i);
+        assert.doesNotMatch(description, /\bMUST use first\b/);
+    });
+
+    test('MCP instructions say to invoke the skill first and explain why', () => {
+        assert.match(serverSource, /invoke the "debug-live" Agent Skill first/i);
+        assert.match(serverSource, /breakpoint strategy/i);
+        assert.match(serverSource, /step-and-inspect/i);
+        assert.match(serverSource, /root-cause guidance/i);
+    });
+
+    test('start_debugging points agents to the skill', () => {
+        assert.match(serverSource, /Invoke the "debug-live" skill first\./);
+    });
+});


### PR DESCRIPTION
## Summary
- refine the debug-live description to explain its root-cause debugging workflow and emphasize using it instead of temporary source-code logs
- keep MCP initialization and start_debugging guidance inline at their usage sites
- add contract tests for skill trigger metadata and MCP guidance
- add an opt-in 
pm run test:skill-trigger-agent evaluation that launches a real Copilot session and asserts debug-live is its first tool call
- bump the extension version to 2.3.1

## Validation
- 
pm run compile`n- 
pm run lint`n- 
pm test (140 passing)
- 
pm run test:skill-trigger-agent (Copilot invoked debug-live first; next tool was g)

The live-agent evaluation is intentionally separate from 
pm test because it requires Copilot authentication, consumes AI credits, and is nondeterministic.