### PR TITLE
docs: explain how to prevent debug focus stealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Let AI agents debug your code inside VS Code - set breakpoints, step through exe
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![VS Code](https://img.shields.io/badge/VS%20Code-1.104.0+-blue.svg)](https://code.visualstudio.com/)
-[![Version](https://img.shields.io/badge/version-2.3.2-green.svg)](https://github.com/microsoft/DebugMCP)
+[![Version](https://img.shields.io/badge/version-2.3.3-green.svg)](https://github.com/microsoft/DebugMCP)
 [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-Install-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ozzafar.debugmcpextension)
 
 > ⭐ **If you find DebugMCP useful, please [star the repo on GitHub](https://github.com/microsoft/DebugMCP)!** It helps others discover the project and motivates continued development.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,17 @@ Yes. DebugMCP supports `.cs` files and `.csproj` project files for C#/.NET debug
   - Check that the breakpoint line number is correct
   - Verify the relevant language debugger extension is installed
 
+#### Another VS Code Window Takes Focus When Debugging Stops
+- **Symptom**: With multiple VS Code windows open, the window being debugged comes to the foreground when it hits a breakpoint or completes a step
+- **Solution**: Disable VS Code's native focus-on-break behavior in your user or workspace settings:
+  ```json
+  {
+    "debug.focusWindowOnBreak": false,
+    "debug.focusEditorOnBreak": false
+  }
+  ```
+  `debug.focusWindowOnBreak` prevents the debugged window from taking operating-system focus. The optional `debug.focusEditorOnBreak` setting also prevents VS Code from moving focus into the stopped source editor. DebugMCP does not change these persistent preferences automatically.
+
 #### Configuration Not Auto-Detected
 - **Symptom**: Extension doesn't prompt to register with your AI assistant
 - **Solution**:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debugmcpextension",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debugmcpextension",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "debugmcpextension",
   "displayName": "DebugMCP — Agentic Debugging for VS Code, Cursor & More",
   "description": "Your AI agent debugs for you — right inside VS Code, Cursor & other VS Code-based editors. Let Copilot, Cline, Cursor, Codex & any MCP agent set breakpoints, step through code, and inspect variables live instead of guessing from logs.",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "publisher": "ozzafar",
   "author": {
     "name": "Oz Zafar",

--- a/skills/debug-live/SKILL.md
+++ b/skills/debug-live/SKILL.md
@@ -237,6 +237,23 @@ Each reference covers prerequisites (which VS Code extension to install), framew
 configuration (e.g. enabling `pytest` test discovery, building `.NET` projects before
 launch), and common pitfalls.
 
+### Multiple VS Code windows
+
+VS Code normally brings a window to the foreground when its debugger stops. If a breakpoint
+or step in one workspace interrupts work in another VS Code window, recommend these native
+VS Code settings:
+
+```json
+{
+  "debug.focusWindowOnBreak": false,
+  "debug.focusEditorOnBreak": false
+}
+```
+
+`debug.focusWindowOnBreak` prevents the debugged window from taking operating-system focus.
+The optional `debug.focusEditorOnBreak` setting also keeps focus out of the stopped source
+editor. Do not change either persistent setting without the user's approval.
+
 ---
 
 ## Things to avoid


### PR DESCRIPTION
## Summary
- document VS Code's native focus-on-break behavior in the troubleshooting guide
- recommend disabling \debug.focusWindowOnBreak\ for multi-window debugging
- document the optional \debug.focusEditorOnBreak\ setting in the debug-live skill
- clarify that DebugMCP does not change persistent user preferences automatically

## Testing
- documentation-only change