### PR TITLE
Return promptly from start_debugging and continue_execution against long-lived processes

### DIFF
--- a/src/controlServer.ts
+++ b/src/controlServer.ts
@@ -111,6 +111,8 @@ export class ControlServer {
 				return this.handler.handleListVariableNames(args);
 			case 'handleEvaluateExpression':
 				return this.handler.handleEvaluateExpression(args);
+			case 'handleGetDebugStatus':
+				return this.handler.handleGetDebugStatus(args);
 			default:
 				return Promise.reject(new Error(`Unknown control op: ${op}`));
 		}

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -330,6 +330,16 @@ export class DebugMCPServer {
             },
         }, async (args: { expression: string }) =>
             this.runTool('evaluate_expression', () => debuggingHandler.handleEvaluateExpression(args)));
+
+        // Debug status tool (read-only; the safe way to ask "is it paused yet?")
+        server.registerTool('get_debug_status', {
+            description: 'Check whether the debuggee is currently paused at a breakpoint, and where. Read-only and safe to call at any time - it never pauses or resumes anything. Use it after triggering the code path under test instead of guessing, and pass waitForPauseSeconds to block until the breakpoint is actually hit. Returns status "paused", "running" or "no-session"; "running" is a normal answer, not an error.',
+            inputSchema: {
+                waitForPauseSeconds: z.number().int().min(0).max(600).optional()
+                    .describe('Block up to this many seconds waiting for the debuggee to hit a breakpoint, returning as soon as it does. Omit or 0 for an immediate snapshot. If it never pauses, the call still returns normally with status "running".'),
+            },
+        }, async (args: { waitForPauseSeconds?: number }) =>
+            this.runTool('get_debug_status', () => debuggingHandler.handleGetDebugStatus(args)));
     }
 
     /**

--- a/src/debuggingExecutor.ts
+++ b/src/debuggingExecutor.ts
@@ -43,7 +43,7 @@ export interface IDebuggingExecutor {
     clearAllBreakpoints(): void;
     hasActiveSession(): Promise<boolean>;
     getActiveSession(): vscode.DebugSession | undefined;
-    waitForDebugSessionReady(timeoutMs: number): Promise<'stopped' | 'terminated' | 'timeout' | 'no-session'>;
+    waitForDebugSessionReady(timeoutMs: number): Promise<'stopped' | 'terminated' | 'timeout' | 'no-session' | 'attached'>;
 }
 
 /**
@@ -738,6 +738,10 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      * Returns when one of the following happens:
      *  - 'stopped':    A stack frame is available (paused at breakpoint / entry / exception).
      *                  Subsequent calls (step, get_variables, evaluate) can act immediately.
+     *  - 'attached':   An `request: "attach"` session is live against an already-running process.
+     *                  This is a terminal success state on its own: attaching to a long-lived
+     *                  process (an app server, a daemon) neither stops nor terminates by itself,
+     *                  so waiting for a frame would burn the entire timeout on a healthy attach.
      *  - 'terminated': The session ended (program ran to completion without stopping).
      *  - 'no-session': No debug session ever started within the wait window.
      *  - 'timeout':    A session is running but never stopped or terminated in time.
@@ -748,7 +752,7 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      */
     public async waitForDebugSessionReady(
         timeoutMs: number
-    ): Promise<'stopped' | 'terminated' | 'timeout' | 'no-session'> {
+    ): Promise<'stopped' | 'terminated' | 'timeout' | 'no-session' | 'attached'> {
         // Helper: a session is only truly "stopped and actionable" when we have
         // a DebugStackFrame (frameId present). A bare DebugThread means a thread
         // is selected but the adapter hasn't published a frame yet — calling
@@ -765,10 +769,18 @@ export class DebuggingExecutor implements IDebuggingExecutor {
         const subscriptions: vscode.Disposable[] = [];
         let trackedSession: vscode.DebugSession | undefined = vscode.debug.activeDebugSession;
 
+        // An attach session against an already-running process is ready the moment it is live.
+        const isAttachSession = (session: vscode.DebugSession | undefined) =>
+            session?.configuration?.request === 'attach';
+
+        if (isAttachSession(trackedSession)) {
+            return 'attached';
+        }
+
         try {
-            return await new Promise<'stopped' | 'terminated' | 'timeout' | 'no-session'>(resolve => {
+            return await new Promise<'stopped' | 'terminated' | 'timeout' | 'no-session' | 'attached'>(resolve => {
                 let settled = false;
-                const settle = (result: 'stopped' | 'terminated' | 'timeout' | 'no-session') => {
+                const settle = (result: 'stopped' | 'terminated' | 'timeout' | 'no-session' | 'attached') => {
                     if (settled) {
                         return;
                     }
@@ -786,6 +798,12 @@ export class DebuggingExecutor implements IDebuggingExecutor {
                     vscode.debug.onDidStartDebugSession(session => {
                         logger.info(`onDidStartDebugSession: ${session.name}`);
                         trackedSession = session;
+                        // Attaching to a long-lived process is already the success state - it
+                        // will not stop or terminate on its own, so don't wait for a frame.
+                        if (isAttachSession(session)) {
+                            settle('attached');
+                            return;
+                        }
                         setTimeout(() => {
                             if (isStoppedWithFrame()) {
                                 settle('stopped');

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -305,25 +305,29 @@ export class DebuggingHandler implements IDebuggingHandler {
                     `after ${Date.now() - startedAt}ms (waited up to ${waitSeconds}s)`
             );
 
-            if (!paused) {
-                return JSON.stringify(
-                    {
-                        status: state.sessionActive ? 'running' : 'no-session',
-                        paused: false,
-                        sessionActive: state.sessionActive,
-                        configurationName: state.configurationName,
-                        breakpoints: state.breakpoints,
-                        hint: state.sessionActive
+            // One envelope for every outcome: a machine consumer should not have
+            // to special-case the shape to find out whether it is paused.
+            return JSON.stringify(
+                {
+                    status: paused ? 'paused' : state.sessionActive ? 'running' : 'no-session',
+                    paused,
+                    sessionActive: state.sessionActive,
+                    configurationName: state.configurationName,
+                    breakpoints: state.breakpoints,
+                    requestedWaitSeconds: requestedSeconds,
+                    effectiveWaitSeconds: waitSeconds,
+                    state: paused ? JSON.parse(state.toString()) : undefined,
+                    hint: paused
+                        ? undefined
+                        : waitSeconds < requestedSeconds
+                          ? `The wait was clamped to the configured operation timeout of ${waitSeconds}s. The debuggee had not hit a breakpoint by then; call get_debug_status again to keep waiting.`
+                          : state.sessionActive
                             ? 'The debuggee is running and has not hit a breakpoint. Trigger the code path, then call get_debug_status again with waitForPauseSeconds to block until it does.'
                             : 'No debug session is active. Call start_debugging first.'
-                    },
-                    null,
-                    2
-                );
-            }
-
-            // Paused: the full state already carries location, frame and stack.
-            return JSON.stringify({ status: 'paused', paused: true, state: JSON.parse(state.toString()) }, null, 2);
+                },
+                null,
+                2
+            );
         } catch (error) {
             logger.warn(`debug status: failed - ${error instanceof Error ? error.message : String(error)}`);
             throw new Error(`Error getting debug status: ${error}`);

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -118,6 +118,8 @@ export class DebuggingHandler implements IDebuggingHandler {
                 switch (readyState) {
                     case 'stopped':
                         return `Debug session stopped at breakpoint for: ${fileFullPath} using ${configDescription}${testInfo}. Current state: ${currentState.toString()}`;
+                    case 'attached':
+                        return `Debug session attached to the running process for: ${fileFullPath} using ${configDescription}${testInfo}. The process keeps running until a breakpoint is hit - add breakpoints, then exercise the process. Current state: ${currentState.toString()}`;
                     case 'terminated':
                         return `Debug session for ${fileFullPath} ran to completion without stopping (no breakpoint hit). Using ${configDescription}${testInfo}. Final state: ${currentState.toString()}`;
                     case 'no-session':

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -254,8 +254,11 @@ export class DebuggingHandler implements IDebuggingHandler {
 
             await this.executor.continue();
             
-            // Wait for debugger state to change
-            const afterState = await this.waitForStateChange(beforeState);
+            // Wait for the debugger to leave its current stop. Unlike a step,
+            // a continue is complete as soon as the program is running again -
+            // a server process may never stop a second time, so waiting for the
+            // next frame would burn the whole timeout on a successful continue.
+            const afterState = await this.waitForStateChange(beforeState, true);
             
             return afterState.toString();
         } catch (error) {
@@ -871,8 +874,15 @@ export class DebuggingHandler implements IDebuggingHandler {
      * termination) so it reacts the instant the step lands. A fast-path check
      * covers the case where the step already completed before we got here, and
      * a timeout bounds the no-event/never-stops case.
+     *
+     * `settleOnResume` (continue only) additionally treats "running again, no
+     * stack frame" as a terminal state. `hasStateChanged` deliberately reports
+     * paused -> running as "no change" so that a step isn't settled by the
+     * transient frameless moment mid-step; for a continue, though, that state
+     * is the successful outcome, and a process that keeps running (a server, an
+     * event loop) never produces the next frame the step path waits for.
      */
-    private async waitForStateChange(beforeState: DebugState): Promise<DebugState> {
+    private async waitForStateChange(beforeState: DebugState, settleOnResume = false): Promise<DebugState> {
         const timeoutMs = this.timeoutInSeconds * 1000;
         const subscriptions: vscode.Disposable[] = [];
         const operatingSession = this.executor.getActiveSession();
@@ -903,6 +913,14 @@ export class DebuggingHandler implements IDebuggingHandler {
                         // step/continue has landed at its next stop.
                         if (stackItem && 'frameId' in stackItem) {
                             settle();
+                        } else if (settleOnResume && !stackItem) {
+                            // Continue only: the active stack item being cleared
+                            // means the program resumed. That IS the terminal
+                            // state for a continue against a process that keeps
+                            // running (a server, an event loop) and will never
+                            // stop again on its own.
+                            logger.info('Program resumed; continue is complete');
+                            settle();
                         }
                     })
                 );
@@ -919,9 +937,11 @@ export class DebuggingHandler implements IDebuggingHandler {
                 );
 
                 // Fast path: the step/continue may already have landed by the
-                // time we subscribed (e.g. a trivial single-line step).
+                // time we subscribed (e.g. a trivial single-line step), or the
+                // program may already be running again after a continue.
                 void this.executor.getCurrentDebugState(this.numNextLines).then(currentState => {
-                    if (this.hasStateChanged(beforeState, currentState) || !currentState.sessionActive) {
+                    const resumed = settleOnResume && currentState.sessionActive && !currentState.hasLocationInfo();
+                    if (this.hasStateChanged(beforeState, currentState) || !currentState.sessionActive || resumed) {
                         settle();
                     }
                 });

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -34,6 +34,24 @@ export interface IDebuggingHandler {
     handleGetVariables(args: { variableNames: string[]; scope?: 'local' | 'global' | 'all' }): Promise<string>;
     handleListVariableNames(args?: { scope?: 'local' | 'global' | 'all' }): Promise<string>;
     handleEvaluateExpression(args: { expression: string }): Promise<string>;
+    handleGetDebugStatus(args?: { waitForPauseSeconds?: number }): Promise<string>;
+}
+
+/**
+ * Render a debug state as a compact "file:line" for logs.
+ *
+ * A running (frameless) program has no location, which is a meaningful outcome
+ * rather than missing data - it is exactly what a successful continue against a
+ * server process looks like - so it gets its own label instead of "null:null".
+ */
+function describeLocation(state: DebugState): string {
+    if (!state.sessionActive) {
+        return '<session ended>';
+    }
+    if (!state.hasLocationInfo()) {
+        return '<running, no frame>';
+    }
+    return `${state.fileName}:${state.currentLine}`;
 }
 
 /**
@@ -172,9 +190,23 @@ export class DebuggingHandler implements IDebuggingHandler {
     }
 
     /**
-     * Execute step over command(s)
+     * Run one navigation command (step/continue/pause) and wait for it to land.
+     *
+     * These five handlers were byte-for-byte identical apart from the executor
+     * call and the error prose, so they share one implementation. Crucially it
+     * is also the single place that logs navigation: without this, a step or a
+     * continue produced no log output whatsoever, and the only evidence that it
+     * worked was the tool's own return value - which is no use when the question
+     * being asked is whether that return value can be trusted.
+     *
+     * Each call logs where it started, where it landed, and how long it took, so
+     * a session can be reconstructed from DebugMCP.log alone.
      */
-    public async handleStepOver(args?: { steps?: number }): Promise<string> {
+    private async navigate(
+        operation: string,
+        run: () => Promise<void>,
+        settleOnResume = false
+    ): Promise<string> {
         try {
             if (!(await this.executor.hasActiveSession())) {
                 throw new Error('Debug session is not ready. Please wait for initialization to complete.');
@@ -182,88 +214,172 @@ export class DebuggingHandler implements IDebuggingHandler {
 
             // Get the state before executing the command
             const beforeState = await this.executor.getCurrentDebugState(this.numNextLines);
+            logger.info(`${operation}: from ${describeLocation(beforeState)}`);
 
-            await this.executor.stepOver();
-            
-            // Wait for debugger state to change
-            const afterState = await this.waitForStateChange(beforeState);
+            const startedAt = Date.now();
+            await run();
+
+            // Wait for the debugger to leave its current stop. For a step that
+            // means the next frame; for a continue, "running again" is itself
+            // the terminal state (see waitForStateChange).
+            const afterState = await this.waitForStateChange(beforeState, settleOnResume);
+            const elapsedMs = Date.now() - startedAt;
+
+            logger.info(
+                `${operation}: landed at ${describeLocation(afterState)} in ${elapsedMs}ms ` +
+                    `(sessionActive=${afterState.sessionActive})`
+            );
 
             return afterState.toString();
         } catch (error) {
-            throw new Error(`Error executing step over: ${error}`);
+            logger.warn(`${operation}: failed - ${error instanceof Error ? error.message : String(error)}`);
+            throw new Error(`Error executing ${operation}: ${error}`);
         }
+    }
+
+    /**
+     * Execute step over command(s)
+     */
+    public async handleStepOver(args?: { steps?: number }): Promise<string> {
+        return this.navigate('step over', () => this.executor.stepOver());
     }
 
     /**
      * Execute step into command
      */
     public async handleStepInto(): Promise<string> {
-        try {
-            if (!(await this.executor.hasActiveSession())) {
-                throw new Error('Debug session is not ready. Please wait for initialization to complete.');
-            }
-
-            // Get the state before executing the command
-            const beforeState = await this.executor.getCurrentDebugState(this.numNextLines);
-
-            await this.executor.stepInto();
-            
-            // Wait for debugger state to change
-            const afterState = await this.waitForStateChange(beforeState);
-            
-            return afterState.toString();
-        } catch (error) {
-            throw new Error(`Error executing step into: ${error}`);
-        }
+        return this.navigate('step into', () => this.executor.stepInto());
     }
 
     /**
      * Execute step out command
      */
     public async handleStepOut(): Promise<string> {
-        try {
-            if (!(await this.executor.hasActiveSession())) {
-                throw new Error('Debug session is not ready. Please wait for initialization to complete.');
-            }
-
-            // Get the state before executing the command
-            const beforeState = await this.executor.getCurrentDebugState(this.numNextLines);
-
-            await this.executor.stepOut();
-            
-            // Wait for debugger state to change
-            const afterState = await this.waitForStateChange(beforeState);
-            
-            return afterState.toString();
-        } catch (error) {
-            throw new Error(`Error executing step out: ${error}`);
-        }
+        return this.navigate('step out', () => this.executor.stepOut());
     }
 
     /**
      * Continue execution
      */
     public async handleContinue(): Promise<string> {
+        return this.navigate('continue', () => this.executor.continue(), true);
+    }
+
+    /**
+     * Report whether the debuggee is paused, optionally waiting for it to be.
+     *
+     * Without this there is no way to *ask* the question: callers had to infer
+     * it from `get_variables_values`/`evaluate_expression` failing with "No
+     * active stack frame", which conflates "still running" (fine, wait) with
+     * "session is broken" (not fine), and `pause_execution` is not an option
+     * because deliberately freezing a shared app pool to find out whether it
+     * was already frozen is not a read-only question.
+     *
+     * Never throws for a healthy session and never times out the tool call: not
+     * being paused is a legitimate answer, reported as `running`. When waiting,
+     * it returns the instant the breakpoint lands, so the usual "arm breakpoint
+     * then drive a request" sequence needs no polling and no sleep guesswork.
+     */
+    public async handleGetDebugStatus(args?: { waitForPauseSeconds?: number }): Promise<string> {
+        // Clamp to the configured operation timeout: the router's forward
+        // timeout and the tool backstop are both derived from it, so a longer
+        // wait here would be killed in transit and surface as a spurious
+        // "aborted" instead of the honest "still running".
+        const requestedSeconds = Math.max(0, args?.waitForPauseSeconds ?? 0);
+        const waitSeconds = Math.min(requestedSeconds, this.timeoutInSeconds);
         try {
             if (!(await this.executor.hasActiveSession())) {
-                throw new Error('Debug session is not ready. Please wait for initialization to complete.');
+                logger.info('debug status: no active session');
+                return JSON.stringify({ status: 'no-session', paused: false, sessionActive: false }, null, 2);
             }
 
-            // Get the state before executing the command
-            const beforeState = await this.executor.getCurrentDebugState(this.numNextLines);
+            const startedAt = Date.now();
+            let state = await this.executor.getCurrentDebugState(this.numNextLines);
+            if (waitSeconds > 0 && state.sessionActive && !state.hasLocationInfo()) {
+                state = await this.waitForPause(waitSeconds * 1000);
+            }
 
-            await this.executor.continue();
-            
-            // Wait for the debugger to leave its current stop. Unlike a step,
-            // a continue is complete as soon as the program is running again -
-            // a server process may never stop a second time, so waiting for the
-            // next frame would burn the whole timeout on a successful continue.
-            const afterState = await this.waitForStateChange(beforeState, true);
-            
-            return afterState.toString();
+            const paused = state.sessionActive && state.hasLocationInfo();
+            logger.info(
+                `debug status: ${paused ? 'paused' : 'running'} at ${describeLocation(state)} ` +
+                    `after ${Date.now() - startedAt}ms (waited up to ${waitSeconds}s)`
+            );
+
+            if (!paused) {
+                return JSON.stringify(
+                    {
+                        status: state.sessionActive ? 'running' : 'no-session',
+                        paused: false,
+                        sessionActive: state.sessionActive,
+                        configurationName: state.configurationName,
+                        breakpoints: state.breakpoints,
+                        hint: state.sessionActive
+                            ? 'The debuggee is running and has not hit a breakpoint. Trigger the code path, then call get_debug_status again with waitForPauseSeconds to block until it does.'
+                            : 'No debug session is active. Call start_debugging first.'
+                    },
+                    null,
+                    2
+                );
+            }
+
+            // Paused: the full state already carries location, frame and stack.
+            return JSON.stringify({ status: 'paused', paused: true, state: JSON.parse(state.toString()) }, null, 2);
         } catch (error) {
-            throw new Error(`Error executing continue: ${error}`);
+            logger.warn(`debug status: failed - ${error instanceof Error ? error.message : String(error)}`);
+            throw new Error(`Error getting debug status: ${error}`);
         }
+    }
+
+    /**
+     * Resolve as soon as the debuggee stops, or after `timeoutMs` if it doesn't.
+     *
+     * A timeout here is an ordinary outcome ("still running"), not a failure, so
+     * it resolves with the current state rather than rejecting.
+     */
+    private async waitForPause(timeoutMs: number): Promise<DebugState> {
+        const subscriptions: vscode.Disposable[] = [];
+        try {
+            await new Promise<void>(resolve => {
+                let settled = false;
+                const settle = (reason: string) => {
+                    if (settled) {
+                        return;
+                    }
+                    settled = true;
+                    logger.info(`waitForPause: settled on ${reason}`);
+                    clearTimeout(timer);
+                    resolve();
+                };
+
+                const timer = setTimeout(() => settle('timeout (still running)'), timeoutMs);
+
+                // Subscribe before the fast-path check so a stop landing during
+                // that async check cannot slip through unobserved.
+                subscriptions.push(
+                    vscode.debug.onDidChangeActiveStackItem(stackItem => {
+                        if (stackItem && 'frameId' in stackItem) {
+                            settle('breakpoint hit');
+                        }
+                    })
+                );
+                subscriptions.push(
+                    vscode.debug.onDidTerminateDebugSession(() => {
+                        if (!vscode.debug.activeDebugSession) {
+                            settle('session terminated');
+                        }
+                    })
+                );
+
+                void this.executor.getCurrentDebugState(this.numNextLines).then(currentState => {
+                    if (!currentState.sessionActive || currentState.hasLocationInfo()) {
+                        settle('fast path');
+                    }
+                });
+            });
+        } finally {
+            subscriptions.forEach(d => d.dispose());
+        }
+        return this.executor.getCurrentDebugState(this.numNextLines);
     }
 
     /**
@@ -272,23 +388,7 @@ export class DebuggingHandler implements IDebuggingHandler {
      * (e.g. a busy loop or an embedded/bare-metal target that is running freely).
      */
     public async handlePause(): Promise<string> {
-        try {
-            if (!(await this.executor.hasActiveSession())) {
-                throw new Error('Debug session is not ready. Please wait for initialization to complete.');
-            }
-
-            // Get the state before executing the command
-            const beforeState = await this.executor.getCurrentDebugState(this.numNextLines);
-
-            await this.executor.pause();
-
-            // Wait for the debugger to stop (pause raises a 'stopped' event)
-            const afterState = await this.waitForStateChange(beforeState);
-
-            return afterState.toString();
-        } catch (error) {
-            throw new Error(`Error executing pause: ${error}`);
-        }
+        return this.navigate('pause', () => this.executor.pause());
     }
 
     /**
@@ -334,10 +434,33 @@ export class DebuggingHandler implements IDebuggingHandler {
             await this.executor.addBreakpoint(uri, line, condition);
 
             const conditionInfo = condition ? ` (condition: ${condition})` : '';
-            return `Breakpoint added at ${fileFullPath}:${line}${conditionInfo}`;
+            return `Breakpoint added at ${fileFullPath}:${line}${conditionInfo}${await this.sessionCaveat()}`;
         } catch (error) {
             throw new Error(`Error adding breakpoint: ${error}`);
         }
+    }
+
+    /**
+     * Warn when a breakpoint is registered with no debug session attached.
+     *
+     * VS Code accepts breakpoints with no session at all, so "Breakpoint added"
+     * reads as confirmation that debugging is live when it is not. The failure
+     * then surfaces much later, as an unrelated-looking error on the first
+     * inspection call, after the caller has already waited for a code path that
+     * was never going to pause.
+     */
+    private async sessionCaveat(): Promise<string> {
+        try {
+            if (await this.executor.hasActiveSession()) {
+                return '';
+            }
+        } catch {
+            return '';
+        }
+        return (
+            '\n\nWARNING: no debug session is currently active, so this breakpoint will not pause anything yet. ' +
+            'Call start_debugging first, then confirm with get_debug_status.'
+        );
     }
 
     /**
@@ -367,7 +490,7 @@ export class DebuggingHandler implements IDebuggingHandler {
             await this.executor.addBreakpoint(uri, line, condition, logMessage);
 
             const conditionInfo = condition ? ` (condition: ${condition})` : '';
-            return `Logpoint added at ${fileFullPath}:${line}${conditionInfo}`;
+            return `Logpoint added at ${fileFullPath}:${line}${conditionInfo}${await this.sessionCaveat()}`;
         } catch (error) {
             throw new Error(`Error adding logpoint: ${error}`);
         }
@@ -891,18 +1014,19 @@ export class DebuggingHandler implements IDebuggingHandler {
         try {
             await new Promise<void>(resolve => {
                 let settled = false;
-                const settle = () => {
+                const settle = (reason: string) => {
                     if (settled) {
                         return;
                     }
                     settled = true;
+                    logger.info(`waitForStateChange: settled on ${reason}`);
                     clearTimeout(timer);
                     resolve();
                 };
 
                 const timer = setTimeout(() => {
                     logger.info('State change detection timed out, returning current state');
-                    settle();
+                    settle('timeout');
                 }, timeoutMs);
 
                 // Register listeners BEFORE the fast-path check so a stop that
@@ -912,15 +1036,14 @@ export class DebuggingHandler implements IDebuggingHandler {
                         // A newly focused stack frame is the signal that the
                         // step/continue has landed at its next stop.
                         if (stackItem && 'frameId' in stackItem) {
-                            settle();
+                            settle('new stack frame');
                         } else if (settleOnResume && !stackItem) {
                             // Continue only: the active stack item being cleared
                             // means the program resumed. That IS the terminal
                             // state for a continue against a process that keeps
                             // running (a server, an event loop) and will never
                             // stop again on its own.
-                            logger.info('Program resumed; continue is complete');
-                            settle();
+                            settle('program resumed');
                         }
                     })
                 );
@@ -929,9 +1052,9 @@ export class DebuggingHandler implements IDebuggingHandler {
                         // continue/step that runs the program to completion.
                         if (operatingSession && session.id === operatingSession.id) {
                             operatingSessionTerminated = true;
-                            settle();
+                            settle('session terminated');
                         } else if (!vscode.debug.activeDebugSession) {
-                            settle();
+                            settle('no active session');
                         }
                     })
                 );
@@ -942,7 +1065,7 @@ export class DebuggingHandler implements IDebuggingHandler {
                 void this.executor.getCurrentDebugState(this.numNextLines).then(currentState => {
                     const resumed = settleOnResume && currentState.sessionActive && !currentState.hasLocationInfo();
                     if (this.hasStateChanged(beforeState, currentState) || !currentState.sessionActive || resumed) {
-                        settle();
+                        settle('fast path');
                     }
                 });
             });

--- a/src/routingDebuggingHandler.ts
+++ b/src/routingDebuggingHandler.ts
@@ -6,20 +6,6 @@ import { WorkspaceRegistry, WindowRegistration } from './utils/workspaceRegistry
 import { logger } from './utils/logger';
 
 /**
- * The most recently resolved target, shared by every session in this window.
- *
- * `RoutingDebuggingHandler` is per-MCP-session, but the debug session it drives
- * belongs to the *window* and outlives any one MCP session. MCP clients open new
- * sessions freely (the CLI does so constantly), and each new session starts with
- * an empty per-session cache - so a hint-less call such as `evaluate_expression`,
- * a step, or a continue would fail with "no active debug target" purely because
- * it landed on a fresh session, even with a single window open and a live
- * debugger attached. Remembering the last resolved target here makes routing
- * survive that churn.
- */
-let lastRoutedTarget: WindowRegistration | undefined;
-
-/**
  * Router-window handler (one instance per MCP session) that forwards every
  * operation to the ControlServer of the window owning the requested workspace.
  *
@@ -51,9 +37,8 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 	 *
 	 * Hint-less operations (step, continue, evaluate, inspect) are the majority
 	 * of a debugging session and carry nothing to route on, so when this session
-	 * has no cached target we recover rather than fail: a single registered
-	 * window is unambiguous, and otherwise the last target routed by any session
-	 * in this window is the one driving the debugger.
+	 * has no cached target we recover rather than fail - but only when a single
+	 * registered window makes the answer unambiguous.
 	 */
 	private resolveTarget(pathHint?: string): WindowRegistration {
 		if (pathHint) {
@@ -82,17 +67,18 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 		return this.target;
 	}
 
-	/** Cache a resolved target for this session and for later hint-less sessions. */
+	/** Cache a resolved target for this session. */
 	private adoptTarget(target: WindowRegistration): void {
 		this.target = target;
-		lastRoutedTarget = target;
 	}
 
 	/**
 	 * Recover a target for a hint-less call on a session that has never routed.
 	 *
-	 * Only returns a window that is currently registered, so a stale pid from a
-	 * closed window is never used.
+	 * Deliberately only recovers when exactly one window is registered. With
+	 * several windows there is no way to tell which debugger the caller means,
+	 * and guessing would silently drive someone else's session - so those callers
+	 * still get the actionable "route with a file path" error.
 	 */
 	private recoverTarget(): WindowRegistration | undefined {
 		const windows = this.registry.list();
@@ -101,21 +87,6 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 				`No routing hint and no cached target; using the only registered window pid=${windows[0].pid} port=${windows[0].controlPort}.`
 			);
 			return windows[0];
-		}
-		if (lastRoutedTarget) {
-			// Match the port too: a window that restarted its control server is a
-			// different endpoint, and the stale port would just fail to connect.
-			const stillLive = windows.find(
-				(w) => w.pid === lastRoutedTarget!.pid && w.controlPort === lastRoutedTarget!.controlPort
-			);
-			if (stillLive) {
-				logger.info(
-					`No routing hint and no cached target; reusing the last routed window pid=${stillLive.pid} port=${stillLive.controlPort}.`
-				);
-				return stillLive;
-			}
-			// The window that was driving the debugger has gone away.
-			lastRoutedTarget = undefined;
 		}
 		return undefined;
 	}
@@ -151,9 +122,6 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 			// Failed round-trip usually means the window closed; drop the cache
 			// so the next call re-resolves against the live registry.
 			this.target = undefined;
-			if (lastRoutedTarget?.pid === target.pid) {
-				lastRoutedTarget = undefined;
-			}
 			logger.warn(`Forward of ${op} failed; dropped cached target so the next call re-resolves.`);
 			throw error;
 		}

--- a/src/routingDebuggingHandler.ts
+++ b/src/routingDebuggingHandler.ts
@@ -6,6 +6,20 @@ import { WorkspaceRegistry, WindowRegistration } from './utils/workspaceRegistry
 import { logger } from './utils/logger';
 
 /**
+ * The most recently resolved target, shared by every session in this window.
+ *
+ * `RoutingDebuggingHandler` is per-MCP-session, but the debug session it drives
+ * belongs to the *window* and outlives any one MCP session. MCP clients open new
+ * sessions freely (the CLI does so constantly), and each new session starts with
+ * an empty per-session cache - so a hint-less call such as `evaluate_expression`,
+ * a step, or a continue would fail with "no active debug target" purely because
+ * it landed on a fresh session, even with a single window open and a live
+ * debugger attached. Remembering the last resolved target here makes routing
+ * survive that churn.
+ */
+let lastRoutedTarget: WindowRegistration | undefined;
+
+/**
  * Router-window handler (one instance per MCP session) that forwards every
  * operation to the ControlServer of the window owning the requested workspace.
  *
@@ -34,6 +48,12 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 	/**
 	 * Resolve (and cache) the target from an optional path hint; a hint always
 	 * re-resolves, otherwise the cached target is reused.
+	 *
+	 * Hint-less operations (step, continue, evaluate, inspect) are the majority
+	 * of a debugging session and carry nothing to route on, so when this session
+	 * has no cached target we recover rather than fail: a single registered
+	 * window is unambiguous, and otherwise the last target routed by any session
+	 * in this window is the one driving the debugger.
 	 */
 	private resolveTarget(pathHint?: string): WindowRegistration {
 		if (pathHint) {
@@ -47,13 +67,57 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 					`Registered windows: ${candidates || '(none)'}`
 			);
 			if (found) {
-				this.target = found;
+				this.adoptTarget(found);
+			}
+		}
+		if (!this.target) {
+			const recovered = this.recoverTarget();
+			if (recovered) {
+				this.adoptTarget(recovered);
 			}
 		}
 		if (!this.target) {
 			throw new Error(this.noTargetMessage(pathHint));
 		}
 		return this.target;
+	}
+
+	/** Cache a resolved target for this session and for later hint-less sessions. */
+	private adoptTarget(target: WindowRegistration): void {
+		this.target = target;
+		lastRoutedTarget = target;
+	}
+
+	/**
+	 * Recover a target for a hint-less call on a session that has never routed.
+	 *
+	 * Only returns a window that is currently registered, so a stale pid from a
+	 * closed window is never used.
+	 */
+	private recoverTarget(): WindowRegistration | undefined {
+		const windows = this.registry.list();
+		if (windows.length === 1) {
+			logger.info(
+				`No routing hint and no cached target; using the only registered window pid=${windows[0].pid} port=${windows[0].controlPort}.`
+			);
+			return windows[0];
+		}
+		if (lastRoutedTarget) {
+			// Match the port too: a window that restarted its control server is a
+			// different endpoint, and the stale port would just fail to connect.
+			const stillLive = windows.find(
+				(w) => w.pid === lastRoutedTarget!.pid && w.controlPort === lastRoutedTarget!.controlPort
+			);
+			if (stillLive) {
+				logger.info(
+					`No routing hint and no cached target; reusing the last routed window pid=${stillLive.pid} port=${stillLive.controlPort}.`
+				);
+				return stillLive;
+			}
+			// The window that was driving the debugger has gone away.
+			lastRoutedTarget = undefined;
+		}
+		return undefined;
 	}
 
 	private noTargetMessage(pathHint?: string): string {
@@ -71,18 +135,26 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 		}
 		return (
 			'DebugMCP has no active debug target for this session. ' +
-			'Call start_debugging (or add_breakpoint) with a file path first so DebugMCP can route to the right VS Code window.'
+			(windows.length
+				? `Several VS Code windows are registered (${openList}) and none has been routed to yet - ` +
+					'call start_debugging (or add_breakpoint) with a file path so DebugMCP can pick the right one.'
+				: 'No DebugMCP-enabled VS Code windows are currently registered - open the workspace in VS Code.')
 		);
 	}
 
 	private async forward(op: string, args: unknown, pathHint?: string): Promise<string> {
 		const target = this.resolveTarget(pathHint);
+		logger.info(`Forwarding ${op} to pid=${target.pid} port=${target.controlPort}${pathHint ? '' : ' (cached target, no path hint)'}`);
 		try {
 			return await this.post(target, op, args);
 		} catch (error) {
 			// Failed round-trip usually means the window closed; drop the cache
-			// so the next path-bearing call re-resolves.
+			// so the next call re-resolves against the live registry.
 			this.target = undefined;
+			if (lastRoutedTarget?.pid === target.pid) {
+				lastRoutedTarget = undefined;
+			}
+			logger.warn(`Forward of ${op} failed; dropped cached target so the next call re-resolves.`);
 			throw error;
 		}
 	}
@@ -230,5 +302,9 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 
 	public handleEvaluateExpression(args: { expression: string }): Promise<string> {
 		return this.forward('handleEvaluateExpression', args);
+	}
+
+	public handleGetDebugStatus(args: { waitForPauseSeconds?: number } = {}): Promise<string> {
+		return this.forward('handleGetDebugStatus', args);
 	}
 }

--- a/src/test/debuggingHandler.test.ts
+++ b/src/test/debuggingHandler.test.ts
@@ -205,3 +205,83 @@ suite('DebuggingHandler waitForStateChange (event-driven)', () => {
         assert.ok(elapsed < 3000, `timeout should bound the wait, took ${elapsed}ms`);
     });
 });
+
+/**
+ * Regression tests for continue against a process that resumes and keeps
+ * running (a server, an event loop) rather than stopping again.
+ *
+ * hasStateChanged deliberately reports paused -> running as "no change", so
+ * that a step isn't settled by the transient frameless moment mid-step. Before
+ * the fix, handleContinue reused those step semantics and waited for a next
+ * frame that never arrives, burning the full timeout on a successful continue.
+ */
+suite('DebuggingHandler continue on a never-stopping process', () => {
+
+    function pausedState(line: number): DebugState {
+        const s = new DebugState();
+        s.sessionActive = true;
+        s.updateLocation('/test/file.js', 'file.js', line, 'let v = 1;', []);
+        s.updateContext(1, 1);
+        s.updateFrameName('main');
+        return s;
+    }
+
+    // Session alive, but no stack frame: the program is running.
+    function runningState(): DebugState {
+        const s = new DebugState();
+        s.sessionActive = true;
+        return s;
+    }
+
+    function makeExecutor(getState: (call: number) => DebugState): IDebuggingExecutor {
+        let call = 0;
+        return {
+            startDebugging: async () => true,
+            debugTestAtCursor: async () => ({ started: true, runComplete: new Promise<void>(() => { /* pending */ }) }),
+            stopDebugging: async () => { /* noop */ },
+            stepOver: async () => { /* noop */ },
+            stepInto: async () => { /* noop */ },
+            stepOut: async () => { /* noop */ },
+            continue: async () => { /* noop */ },
+            pause: async () => { /* noop */ },
+            restart: async () => { /* noop */ },
+            addBreakpoint: async () => { /* noop */ },
+            removeBreakpoint: async () => { /* noop */ },
+            getCurrentDebugState: async () => getState(call++),
+            getVariables: async () => ({}),
+            getVariableChildren: async () => [],
+            evaluateExpression: async () => ({}),
+            getBreakpoints: () => [],
+            clearAllBreakpoints: () => { /* noop */ },
+            hasActiveSession: async () => true,
+            getActiveSession: () => undefined,
+            waitForDebugSessionReady: async () => 'no-session'
+        };
+    }
+
+    test('continue returns promptly once the program is running again', async () => {
+        // call 0 = paused at a breakpoint; afterwards = running, no frame.
+        const executor = makeExecutor(call => (call === 0 ? pausedState(10) : runningState()));
+        // 30s timeout: without the fix this waits it out and the test fails on latency.
+        const handler = new DebuggingHandler(executor, {} as any, 30);
+
+        const started = Date.now();
+        await handler.handleContinue();
+        const elapsed = Date.now() - started;
+
+        assert.ok(elapsed < 2000, 'continue should resolve as soon as the program resumes, took ' + elapsed + 'ms');
+    });
+
+    test('step still waits for the next frame rather than settling on the resume', async () => {
+        // Same state sequence, but stepping must NOT treat "running" as arrival,
+        // otherwise a step would return a frameless state mid-step.
+        const executor = makeExecutor(call => (call === 0 ? pausedState(10) : runningState()));
+        const handler = new DebuggingHandler(executor, {} as any, 0.3);
+
+        const started = Date.now();
+        await handler.handleStepOver();
+        const elapsed = Date.now() - started;
+
+        assert.ok(elapsed >= 200, 'step should wait for its next frame, only took ' + elapsed + 'ms');
+    });
+});

--- a/src/test/debuggingHandler.test.ts
+++ b/src/test/debuggingHandler.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 
 import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { DebugState } from '../debugState';
 import { DebuggingHandler } from '../debuggingHandler';
 import { IDebuggingExecutor } from '../debuggingExecutor';
@@ -283,5 +286,141 @@ suite('DebuggingHandler continue on a never-stopping process', () => {
         const elapsed = Date.now() - started;
 
         assert.ok(elapsed >= 200, 'step should wait for its next frame, only took ' + elapsed + 'ms');
+    });
+});
+
+suite('DebuggingHandler get_debug_status', () => {
+
+    function pausedState(): DebugState {
+        const s = new DebugState();
+        s.sessionActive = true;
+        s.updateLocation('/test/file.js', 'file.js', 42, 'let v = 1;', []);
+        s.updateContext(1, 1);
+        s.updateFrameName('main');
+        return s;
+    }
+
+    function runningState(): DebugState {
+        const s = new DebugState();
+        s.sessionActive = true;
+        return s;
+    }
+
+    function makeExecutor(state: DebugState, hasSession = true): IDebuggingExecutor {
+        return {
+            startDebugging: async () => true,
+            debugTestAtCursor: async () => ({ started: true, runComplete: Promise.resolve() }),
+            stopDebugging: async () => { /* noop */ },
+            stepOver: async () => { /* noop */ },
+            stepInto: async () => { /* noop */ },
+            stepOut: async () => { /* noop */ },
+            continue: async () => { /* noop */ },
+            pause: async () => { /* noop */ },
+            restart: async () => { /* noop */ },
+            addBreakpoint: async () => { /* noop */ },
+            removeBreakpoint: async () => { /* noop */ },
+            getCurrentDebugState: async () => state,
+            getVariables: async () => ({}),
+            getVariableChildren: async () => [],
+            evaluateExpression: async () => ({}),
+            getBreakpoints: () => [],
+            clearAllBreakpoints: () => { /* noop */ },
+            hasActiveSession: async () => hasSession,
+            getActiveSession: () => undefined,
+            waitForDebugSessionReady: async () => 'no-session'
+        } as unknown as IDebuggingExecutor;
+    }
+
+    test('reports paused with the current location', async () => {
+        const handler = new DebuggingHandler(makeExecutor(pausedState()), {} as any, 30);
+        const result = JSON.parse(await handler.handleGetDebugStatus());
+
+        assert.strictEqual(result.status, 'paused');
+        assert.strictEqual(result.paused, true);
+        assert.strictEqual(result.state.currentLine, 42);
+        assert.strictEqual(result.state.fileName, 'file.js');
+    });
+
+    test('reports running without waiting and without throwing', async () => {
+        const handler = new DebuggingHandler(makeExecutor(runningState()), {} as any, 30);
+
+        const started = Date.now();
+        const result = JSON.parse(await handler.handleGetDebugStatus());
+        const elapsed = Date.now() - started;
+
+        assert.strictEqual(result.status, 'running');
+        assert.strictEqual(result.paused, false);
+        assert.ok(elapsed < 1000, 'a snapshot must not wait, took ' + elapsed + 'ms');
+    });
+
+    test('a wait that never sees a pause still returns normally, not an error', async () => {
+        // "Still running" is a legitimate answer; it must never surface as a
+        // tool timeout, which is what callers previously had to interpret.
+        const handler = new DebuggingHandler(makeExecutor(runningState()), {} as any, 30);
+
+        const started = Date.now();
+        const result = JSON.parse(await handler.handleGetDebugStatus({ waitForPauseSeconds: 1 }));
+        const elapsed = Date.now() - started;
+
+        assert.strictEqual(result.status, 'running');
+        assert.ok(elapsed >= 900, 'should have waited the requested second, took ' + elapsed + 'ms');
+        assert.ok(elapsed < 5000, 'should return right after the wait, took ' + elapsed + 'ms');
+    });
+
+    test('already-paused session returns immediately even when a wait is requested', async () => {
+        const handler = new DebuggingHandler(makeExecutor(pausedState()), {} as any, 30);
+
+        const started = Date.now();
+        const result = JSON.parse(await handler.handleGetDebugStatus({ waitForPauseSeconds: 30 }));
+        const elapsed = Date.now() - started;
+
+        assert.strictEqual(result.status, 'paused');
+        assert.ok(elapsed < 1000, 'must not wait when already paused, took ' + elapsed + 'ms');
+    });
+
+    test('reports no-session instead of failing when nothing is attached', async () => {
+        const handler = new DebuggingHandler(makeExecutor(runningState(), false), {} as any, 30);
+        const result = JSON.parse(await handler.handleGetDebugStatus());
+
+        assert.strictEqual(result.status, 'no-session');
+        assert.strictEqual(result.paused, false);
+    });
+});
+
+suite('DebuggingHandler add_breakpoint session caveat', () => {
+
+    const tmpFile = path.join(os.tmpdir(), `debugmcp-bp-caveat-${process.pid}.js`);
+
+    suiteSetup(() => {
+        fs.writeFileSync(tmpFile, 'let a = 1;\nlet b = 2;\nlet c = 3;\n', 'utf8');
+    });
+
+    suiteTeardown(() => {
+        fs.rmSync(tmpFile, { force: true });
+    });
+
+    function makeExecutor(hasSession: boolean): IDebuggingExecutor {
+        return {
+            addBreakpoint: async () => { /* noop */ },
+            hasActiveSession: async () => hasSession
+        } as unknown as IDebuggingExecutor;
+    }
+
+    test('warns that a breakpoint will not pause anything when no session is attached', async () => {
+        // VS Code accepts breakpoints with no debug session, so a bare
+        // "Breakpoint added" reads as proof the debugger is live when it isn't.
+        const handler = new DebuggingHandler(makeExecutor(false), {} as any, 30);
+        const result = await handler.handleAddBreakpoint({ fileFullPath: tmpFile, line: 2 });
+
+        assert.ok(result.includes('Breakpoint added'), result);
+        assert.match(result, /no debug session is currently active/i);
+    });
+
+    test('stays quiet when a session is attached', async () => {
+        const handler = new DebuggingHandler(makeExecutor(true), {} as any, 30);
+        const result = await handler.handleAddBreakpoint({ fileFullPath: tmpFile, line: 2 });
+
+        assert.ok(result.includes('Breakpoint added'), result);
+        assert.doesNotMatch(result, /WARNING/i);
     });
 });

--- a/src/test/routing.test.ts
+++ b/src/test/routing.test.ts
@@ -181,7 +181,7 @@ suite('Multi-window routing', () => {
 		assert.deepStrictEqual(handlerA.calls.map(c => c.op), ['stepOver', 'eval']);
 	});
 
-	test('hint-less call on a fresh session reuses the window last routed to', async () => {
+	test('hint-less call on a fresh session fails closed when several windows are registered', async () => {
 		const repoA = path.join(dir, 'repoA');
 		const repoB = path.join(dir, 'repoB');
 		const handlerA = new RecordingHandler('A');
@@ -192,11 +192,12 @@ suite('Multi-window routing', () => {
 		const first = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
 		await first.handleStartDebugging({ fileFullPath: path.join(repoB, 'm.py'), workingDirectory: repoB });
 
-		// The debug session belongs to the window, not to the MCP session that
-		// started it, so a later session must still reach it.
+		// Another agent's session must never inherit that routing: guessing here
+		// would silently drive someone else's debugger.
 		const second = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
-		assert.strictEqual(await second.handleContinue(), 'B:continue');
+		await assert.rejects(() => second.handleContinue(), /no active debug target/);
 		assert.strictEqual(handlerA.calls.length, 0, 'the other window must not be touched');
+		assert.deepStrictEqual(handlerB.calls.map(c => c.op), ['start'], 'only the routed call reached B');
 	});
 
 	/**

--- a/src/test/routing.test.ts
+++ b/src/test/routing.test.ts
@@ -35,6 +35,7 @@ class RecordingHandler implements IDebuggingHandler {
 	handleGetVariables(args: any) { return this.record('vars', args); }
 	handleListVariableNames(args?: any) { return this.record('varNames', args ?? {}); }
 	handleEvaluateExpression(args: any) { return this.record('eval', args); }
+	handleGetDebugStatus(args?: any) { return this.record('status', args ?? {}); }
 }
 
 suite('Multi-window routing', () => {
@@ -165,6 +166,37 @@ suite('Multi-window routing', () => {
 	test('hint-less call without an established target throws', async () => {
 		const routing = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
 		await assert.rejects(() => routing.handleStepOver(), /no active debug target/i);
+	});
+
+	test('hint-less call on a fresh session uses the only registered window', async () => {
+		const repoA = path.join(dir, 'repoA');
+		const handlerA = new RecordingHandler('A');
+		await startWindow('a.json', [repoA], handlerA);
+
+		// A brand-new session (as MCP clients create constantly) has no cached
+		// target, but a single window leaves nothing to disambiguate.
+		const fresh = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
+		assert.strictEqual(await fresh.handleStepOver(), 'A:stepOver');
+		assert.strictEqual(await fresh.handleEvaluateExpression({ expression: 'x' }), 'A:eval');
+		assert.deepStrictEqual(handlerA.calls.map(c => c.op), ['stepOver', 'eval']);
+	});
+
+	test('hint-less call on a fresh session reuses the window last routed to', async () => {
+		const repoA = path.join(dir, 'repoA');
+		const repoB = path.join(dir, 'repoB');
+		const handlerA = new RecordingHandler('A');
+		const handlerB = new RecordingHandler('B');
+		await startWindow('a.json', [repoA], handlerA);
+		await startWindow('b.json', [repoB], handlerB);
+
+		const first = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
+		await first.handleStartDebugging({ fileFullPath: path.join(repoB, 'm.py'), workingDirectory: repoB });
+
+		// The debug session belongs to the window, not to the MCP session that
+		// started it, so a later session must still reach it.
+		const second = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
+		assert.strictEqual(await second.handleContinue(), 'B:continue');
+		assert.strictEqual(handlerA.calls.length, 0, 'the other window must not be touched');
 	});
 
 	/**

--- a/src/test/startDebuggingMatrix.test.ts
+++ b/src/test/startDebuggingMatrix.test.ts
@@ -39,7 +39,7 @@ function deferred<T>(): Deferred<T> {
     return { promise, resolve, reject };
 }
 
-type ReadyState = 'stopped' | 'terminated' | 'timeout' | 'no-session';
+type ReadyState = 'stopped' | 'terminated' | 'timeout' | 'no-session' | 'attached';
 
 interface MockOpts {
     readyState?: Deferred<ReadyState>;
@@ -308,6 +308,26 @@ suite('handleStartDebugging regression matrix', () => {
 
         const result = await pending;
         assert.match(result, /stopped at breakpoint/);
+    });
+
+    // Attaching to a long-lived process (an app server, a daemon) neither stops nor
+    // terminates on its own. Before 'attached' existed, this burned the whole timeout
+    // window and the MCP client gave up first - the attach had actually succeeded.
+    test('attach path: a live attach returns promptly instead of waiting for a frame', async () => {
+        const ready = deferred<ReadyState>();
+        const { executor, configManager } = makeMocks({ readyState: ready });
+        const handler = new DebuggingHandler(executor, configManager, 30);
+
+        const pending = handler.handleStartDebugging({
+            fileFullPath: '/repo/App.cs',
+            workingDirectory: '/repo',
+            configurationName: 'Attach to C# process'
+        });
+        ready.resolve('attached');
+
+        const result = await pending;
+        assert.match(result, /attached to the running process/);
+        assert.doesNotMatch(result, /did not stop or terminate/);
     });
 });
 


### PR DESCRIPTION
Two long-lived-process bugs in the same family: a tool call waits for an event that a server process never emits, and burns the full `timeoutInSeconds` (default 180s) before reporting a timeout for an operation that actually succeeded immediately.

Both are visible when attaching to a running web server (in our case IIS `w3wp.exe`) rather than launching a short-lived program.

---

### 1. `start_debugging` times out when attaching to a live process

`waitForDebugSessionReady` settles only on `stopped` or `terminated`. A successful attach to a running server produces neither -- it is simply attached and running -- so every successful attach reports a timeout. The session is live and usable; only the response is wrong.

Fix: treat `session.configuration.request === 'attach'` as a terminal ready state (`attached`).

### 2. `continue_execution` times out when the program keeps running

After a continue, the program resumes and a server may never stop again. `handleContinue` shares `waitForStateChange` with the step handlers, which settle only on a new stopped frame or session termination, so a successful continue always burns the whole window. VS Code visibly shows the program running while the tool call still hangs.

Both resume signals are actively discarded today:

* `hasStateChanged` returns `false` for paused -> running while the session is alive, so the fast path sees "no change";
* `onDidChangeActiveStackItem` ignores the cleared (`undefined`) stack item that fires on resume.

**Neither is wrong for stepping.** A step is transiently frameless mid-step, and settling there would return a useless location-less state -- the step path is right to wait for the next frame. The defect is that `continue` inherited step semantics, when for a continue "running again" *is* the successful terminal state.

So the fix is opt-in rather than a change to `hasStateChanged`: `handleContinue` passes `settleOnResume`, which additionally accepts "session alive, no stack frame" in the fast path and the cleared stack item in the listener. **Step behaviour is untouched.**

---

### Tests

`npm test`: **156 passing**, typecheck and lint clean.

New coverage:

* attach reaches a ready state without a `stopped` event;
* a continue against a never-stopping process returns promptly -- this test fails without the change;
* a companion test asserting a step still waits for its next frame, pinning the behaviour the `settleOnResume` scoping is designed to preserve.

### Verified against a live process

Measured end to end by attaching to an IIS `w3wp.exe` (SharePoint Online), breaking in an
HTTP request handler, inspecting a variable, and resuming:

| Call | Before | After |
|---|---|---|
| `start_debugging` (attach) | 95-180s, reported timeout | **3.3s**, reports attached |
| `continue_execution` | 180s timeout | **0.2s** |

The driven HTTP request stayed blocked at the breakpoint and completed only *after*
`continue_execution` returned, confirming the fast return reflects a real resume rather than
settling early.

