### PR TITLE
Add Ruby LSP debugging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DebugMCP will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Ruby debugging now uses Shopify Ruby LSP correctly.** Automatic `.rb` launch configurations target the modern `ruby_lsp` debug adapter and pass the Ruby command and file separately, including paths with spaces. Scalar rdbg values are returned instead of being mistaken for complex objects, synthetic class metadata is omitted, Ruby arrays use indexed DAP retrieval, and RSpec Testing API launches continue past rdbg's entry pause to the configured breakpoint. Documentation no longer points to the deprecated `rebornix.ruby` extension.
+
 ## [2.3.0] - 2026-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ DebugMCP supports debugging for the following languages with their respective VS
 | **Go** | [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go) | `.go` | ✅ Fully Supported |
 | **Rust** | [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) | `.rs` | ✅ Fully Supported |
 | **PHP** | [PHP Debug](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug) | `.php` | ✅ Fully Supported |
-| **Ruby** | [Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.ruby) | `.rb` | ✅ Fully Supported |
+| **Ruby** | [Ruby](https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp) | `.rb` | ✅ Fully Supported |
 | **C#/.NET** | [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) | `.cs`, `.csproj` | ✅ Fully Supported |
 
 ## Configuration
@@ -428,7 +428,7 @@ The extension handles debug configurations intelligently:
   - **Go**: [Go extension](vscode:extension/golang.go)
   - **Rust**: [rust-analyzer extension](vscode:extension/rust-lang.rust-analyzer)
   - **PHP**: [PHP Debug extension](vscode:extension/xdebug.php-debug)
-  - **Ruby**: [Ruby extension](vscode:extension/rebornix.ruby) with debug support
+  - **Ruby**: [Ruby extension](vscode:extension/Shopify.ruby-lsp) and the [`debug` gem](https://github.com/ruby/debug)
 - MCP-compatible AI assistant (Copilot, Cline, Cursor, Codex, Windsurf, Roo Code, etc.)
 
 ## Development

--- a/docs/architecture/debugConfigurationManager.md
+++ b/docs/architecture/debugConfigurationManager.md
@@ -16,7 +16,8 @@ Delegating to those mechanisms keeps this class small and ensures defaults stay 
 ## Responsibility
 
 - Return a launch.json configuration name when the caller provides one — VS Code looks it up itself.
-- Otherwise, return a minimal launch stub (`type`, `request`, `name`, `program`) for the file's language and let the language extension resolve the rest.
+- Otherwise, return a minimal launch stub for the file's language and let the language extension resolve the rest.
+- For Ruby, use Shopify Ruby LSP's `ruby_lsp` adapter and pass `command` and `file` separately so the adapter safely quotes the target path.
 - For `.NET` (`coreclr`), locate the project's built DLL since `program` cannot be a `.cs` source file.
 - Detect the debugger `type` from a file extension.
 
@@ -39,7 +40,7 @@ Maps file extensions to debugger `type` values:
 - `.go` → `go`
 - `.rs` → `lldb`
 - `.php` → `php`
-- `.rb` → `ruby`
+- `.rb` → `ruby_lsp`
 
 ### Test framework support
 
@@ -49,7 +50,8 @@ Test launches are dispatched via `DebuggingExecutor.debugTestAtCursor`, not via 
 
 1. If `configurationName` is provided and is not the sentinel `Default Configuration`, return that name verbatim.
 2. Otherwise, if the file is C# (`coreclr`), walk up to find the `.csproj`, locate its built DLL under `bin/{Debug,Release}/<tfm>/`, and return a coreclr config pointing at that assembly.
-3. Otherwise, return `{ type, request: 'launch', name: 'DebugMCP Launch', program: fileFullPath }`.
+3. For Ruby (`ruby_lsp`), return `{ type, request: 'launch', name: 'DebugMCP Launch', command: 'ruby', file: fileFullPath }`.
+4. Otherwise, return `{ type, request: 'launch', name: 'DebugMCP Launch', program: fileFullPath }`.
 
 ## Key code locations
 

--- a/docs/architecture/debuggingExecutor.md
+++ b/docs/architecture/debuggingExecutor.md
@@ -62,6 +62,9 @@ For data retrieval, the executor uses DAP's custom request mechanism:
 
 All custom requests go through `dapRequest()`, which caps each call so an
 unresponsive adapter rejects with an error instead of hanging the caller.
+Indexed child collections use DAP's `filter: indexed` request form. This is
+required by rdbg for Ruby arrays and is also the standard paging path for other
+adapters that advertise `indexedVariables`.
 
 For Cortex-Debug sessions, common GDB inspection commands are adapted to DAP
 operations that return structured results instead of relying on Debug Console

--- a/docs/architecture/debuggingHandler.md
+++ b/docs/architecture/debuggingHandler.md
@@ -59,6 +59,14 @@ A state change is considered meaningful when any of these change:
 - Frame name (function/method)
 - Frame ID
 
+### Ruby test entry pause
+
+Ruby rdbg emits an initial stopped frame when the Ruby LSP Testing API starts an
+RSpec example. When project breakpoints exist and that frame is not one of them,
+the handler continues once and waits for the actual breakpoint before returning
+from `start_debugging`. Other adapters and deliberate no-breakpoint entry pauses
+are unchanged.
+
 ### Root Cause Analysis
 
 When debugging stops, the handler prompts AI agents to consider whether they found the root cause or just a symptom, encouraging deeper investigation.
@@ -82,6 +90,7 @@ content (JWT, PEM private key, `AKIA…`, `ghp_…`, `Bearer …`, `Password=…
 bypass for per-variable controls. Null-ish values are deliberately left intact so
 missing-credential bugs stay debuggable.
 `handleGetVariables` and `handleEvaluateExpression` return the explicitly requested variable or expression's own result, but any expandable descendants are rendered as names and types only. A descendant value requires evaluating that exact path separately.
+Scalar Ruby values remain scalar even when rdbg supplies a `variablesReference` for implementation metadata such as `#class`; DebugMCP returns the value and does not recursively expand that metadata. Synthetic rdbg `#class` and `%ancestors` children are omitted from aggregate expansion so user fields remain visible.
 Recursive expansion is bounded to 100 child fields total per response, shared across all nested branches and requested roots.
 
 ## Key Code Locations

--- a/src/debuggingExecutor.ts
+++ b/src/debuggingExecutor.ts
@@ -20,6 +20,10 @@ export interface TestDebugDispatch {
     runComplete: Promise<void>;
 }
 
+export interface VariableChildrenOptions {
+    indexedVariables?: number;
+}
+
 /**
  * Interface for debugging execution operations
  */
@@ -37,7 +41,7 @@ export interface IDebuggingExecutor {
     removeBreakpoint(uri: vscode.Uri, line: number): Promise<void>;
     getCurrentDebugState(numNextLines: number): Promise<DebugState>;
     getVariables(frameId: number, scope?: 'local' | 'global' | 'all'): Promise<any>;
-    getVariableChildren(variablesReference: number): Promise<any[]>;
+    getVariableChildren(variablesReference: number, options?: VariableChildrenOptions): Promise<any[]>;
     evaluateExpression(expression: string, frameId: number): Promise<any>;
     getBreakpoints(): readonly vscode.Breakpoint[];
     clearAllBreakpoints(): void;
@@ -551,7 +555,10 @@ export class DebuggingExecutor implements IDebuggingExecutor {
      * handler only reads children for variables explicitly requested by the
      * caller, rather than recursively dumping every value in scope.
      */
-    public async getVariableChildren(variablesReference: number): Promise<any[]> {
+    public async getVariableChildren(
+        variablesReference: number,
+        options: VariableChildrenOptions = {}
+    ): Promise<any[]> {
         if (variablesReference <= 0) {
             return [];
         }
@@ -562,8 +569,14 @@ export class DebuggingExecutor implements IDebuggingExecutor {
                 throw new Error('No active debug session');
             }
 
+            const indexedVariables = Number(options.indexedVariables) || 0;
             const response = await this.dapRequest(activeSession, 'variables', {
-                variablesReference
+                variablesReference,
+                ...(indexedVariables > 0 ? {
+                    filter: 'indexed',
+                    start: 0,
+                    count: indexedVariables
+                } : {})
             });
             return response?.variables || [];
         } catch (error) {

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -103,7 +103,7 @@ export class DebuggingHandler implements IDebuggingHandler {
                 // (and any runner where onDidTerminateDebugSession doesn't fire
                 // reliably for parent/child sessions), the test-run-complete signal
                 // is what tells us a clean run finished without ever pausing.
-                const readyState = testRunComplete
+                let readyState = testRunComplete
                     ? await Promise.race([
                         readyPromise,
                         testRunComplete.then(() => 'terminated' as const)
@@ -112,7 +112,24 @@ export class DebuggingHandler implements IDebuggingHandler {
 
                 logger.info(`handleStartDebugging: readyState=${readyState}, fetching current state…`);
                 const testInfo = testName ? ` (test: ${testName})` : '';
-                const currentState = await this.executor.getCurrentDebugState(this.numNextLines);
+                let currentState = await this.executor.getCurrentDebugState(this.numNextLines);
+
+                // rdbg reports its debugger-entry pause before the requested
+                // RSpec breakpoint. Continue that Ruby Testing API session once
+                // so start_debugging returns at the user's actual breakpoint.
+                if (readyState === 'stopped' &&
+                    testRunComplete &&
+                    this.executor.getActiveSession()?.type.toLowerCase() === 'ruby_lsp' &&
+                    this.shouldContinueToConfiguredBreakpoint(currentState)) {
+                    const breakpointReady = this.executor.waitForDebugSessionReady(this.timeoutInSeconds * 1000);
+                    await this.executor.continue();
+                    readyState = await Promise.race([
+                        breakpointReady,
+                        testRunComplete.then(() => 'terminated' as const)
+                    ]);
+                    currentState = await this.executor.getCurrentDebugState(this.numNextLines);
+                }
+
                 logger.info('handleStartDebugging: got current state, returning response');
 
                 switch (readyState) {
@@ -131,6 +148,16 @@ export class DebuggingHandler implements IDebuggingHandler {
         } catch (error) {
             throw new Error(`Error starting debug session: ${error}`);
         }
+    }
+
+    private shouldContinueToConfiguredBreakpoint(state: DebugState): boolean {
+        if (!state.fileName || state.currentLine === null || state.breakpoints.length === 0) {
+            return false;
+        }
+
+        const location = `${state.fileName}:${state.currentLine}`;
+        return !state.breakpoints.some(breakpoint =>
+            breakpoint === location || breakpoint.startsWith(`${location} [`));
     }
 
     /**
@@ -553,6 +580,25 @@ export class DebuggingHandler implements IDebuggingHandler {
     }
 
     /**
+     * Some adapters expose implementation metadata as children of scalar
+     * values. Ruby rdbg, for example, gives Integer and String values a
+     * variablesReference for #class and other internals. Those references do
+     * not make the user value an aggregate and should not hide its result.
+     */
+    private static isScalarLikeType(type: unknown): boolean {
+        if (typeof type !== 'string') {
+            return false;
+        }
+
+        const typeName = type.split(/\r?\n/, 1)[0].trim();
+        return /^(?:Integer|Float|Rational|Complex|String|Symbol|TrueClass|FalseClass|NilClass|Regexp)$/.test(typeName);
+    }
+
+    private static isAdapterMetadataVariable(variable: any): boolean {
+        return variable?.name === '#class' || variable?.name === '%ancestors';
+    }
+
+    /**
      * List the variable names (and types) visible at the current execution
      * point, deliberately without any values, so an agent can discover what
      * exists and then request only the ones it needs.
@@ -692,7 +738,8 @@ export class DebuggingHandler implements IDebuggingHandler {
             if (response && response.result !== undefined) {
                 let resultText = `Expression: ${expression}\n`;
                 const isComplex = response.variablesReference > 0 &&
-                    !DebuggingHandler.isPointerLikeType(response.type);
+                    !DebuggingHandler.isPointerLikeType(response.type) &&
+                    !DebuggingHandler.isScalarLikeType(response.type);
                 const expressionIsSensitive = isSensitiveExpression(expression);
                 const { value, redacted } = isComplex
                     ? {
@@ -710,7 +757,8 @@ export class DebuggingHandler implements IDebuggingHandler {
                         '  ',
                         1,
                         new Set<number>(),
-                        { remaining: this.maxExpandedFields }
+                        { remaining: this.maxExpandedFields },
+                        response
                     );
                     if (children.text) {
                         resultText += `\n${children.text}`;
@@ -759,7 +807,8 @@ export class DebuggingHandler implements IDebuggingHandler {
         let redacted = false;
         const variablesReference = Number(variable.variablesReference) || 0;
         const isComplex = variablesReference > 0 &&
-            !DebuggingHandler.isPointerLikeType(variable.type);
+            !DebuggingHandler.isPointerLikeType(variable.type) &&
+            !DebuggingHandler.isScalarLikeType(variable.type);
         if (includeValue && isComplex) {
             const redactionName = DebuggingHandler.redactionVariableName(variable, name);
             if (isSensitiveName(redactionName)) {
@@ -783,7 +832,8 @@ export class DebuggingHandler implements IDebuggingHandler {
                 `${indent}  `,
                 depth + 1,
                 visitedReferences,
-                expansionBudget
+                expansionBudget,
+                variable
             );
             if (children.text) {
                 text += `\n${children.text}`;
@@ -799,7 +849,8 @@ export class DebuggingHandler implements IDebuggingHandler {
         indent: string,
         depth: number,
         visitedReferences: Set<number>,
-        expansionBudget: { remaining: number }
+        expansionBudget: { remaining: number },
+        parent: any = {}
     ): Promise<{ text: string; redacted: boolean }> {
         if (depth > this.maxVariableExpansionDepth) {
             return { text: `${indent}<maximum expansion depth reached>`, redacted: false };
@@ -810,7 +861,9 @@ export class DebuggingHandler implements IDebuggingHandler {
 
         const nextVisited = new Set(visitedReferences);
         nextVisited.add(variablesReference);
-        const children = await this.executor.getVariableChildren(variablesReference);
+        const children = (await this.executor.getVariableChildren(variablesReference, {
+            indexedVariables: parent.indexedVariables
+        })).filter(child => !DebuggingHandler.isAdapterMetadataVariable(child));
         const rendered: string[] = [];
         let redacted = false;
         let renderedChildren = 0;

--- a/src/test/debugConfigurationManager.test.ts
+++ b/src/test/debugConfigurationManager.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import { DebugConfigurationManager } from '../utils/debugConfigurationManager';
+
+suite('DebugConfigurationManager', () => {
+    const manager = new DebugConfigurationManager();
+
+    test('uses the Ruby LSP debug adapter for Ruby files', () => {
+        assert.strictEqual(manager.detectLanguageFromFilePath('/repo/example.rb'), 'ruby_lsp');
+    });
+
+    test('creates a Ruby LSP launch config with a separate command and file', async () => {
+        const fileFullPath = '/repo/with spaces/example.rb';
+
+        const config = await manager.getDebugConfig('/repo', fileFullPath);
+
+        assert.deepStrictEqual(config, {
+            type: 'ruby_lsp',
+            request: 'launch',
+            name: 'DebugMCP Launch',
+            command: 'ruby',
+            file: fileFullPath
+        });
+    });
+
+    test('preserves explicitly named launch configurations for Ruby', async () => {
+        const config = await manager.getDebugConfig('/repo', '/repo/example.rb', 'Debug Rails');
+
+        assert.strictEqual(config, 'Debug Rails');
+    });
+});

--- a/src/test/rubyInspection.test.ts
+++ b/src/test/rubyInspection.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { DebuggingHandler } from '../debuggingHandler';
+import { DebuggingExecutor, IDebuggingExecutor } from '../debuggingExecutor';
+
+suite('Ruby rdbg variable inspection', () => {
+    function withActiveFrame<T>(run: () => Promise<T>): Promise<T> {
+        const descriptor = Object.getOwnPropertyDescriptor(vscode.debug, 'activeStackItem');
+        Object.defineProperty(vscode.debug, 'activeStackItem', {
+            configurable: true,
+            get: () => ({ frameId: 1, threadId: 1, session: {} })
+        });
+        return run().finally(() => {
+            if (descriptor) {
+                Object.defineProperty(vscode.debug, 'activeStackItem', descriptor);
+            }
+        });
+    }
+
+    test('returns scalar values instead of expanding rdbg metadata', async () => {
+        let expanded = false;
+        const executor = {
+            hasActiveSession: async () => true,
+            getVariables: async () => ({
+                scopes: [{
+                    name: 'Local variables',
+                    variables: [{
+                        name: 'probe_value',
+                        value: '41',
+                        type: 'Integer',
+                        variablesReference: 10
+                    }]
+                }]
+            }),
+            getVariableChildren: async () => {
+                expanded = true;
+                return [{ name: '#class', type: 'Class', variablesReference: 11 }];
+            }
+        } as unknown as IDebuggingExecutor;
+
+        await withActiveFrame(async () => {
+            const output = await new DebuggingHandler(executor, {} as any, 30)
+                .handleGetVariables({ variableNames: ['probe_value'], scope: 'local' });
+
+            assert.match(output, /probe_value: 41 \(Integer\)/);
+            assert.doesNotMatch(output, /#class/);
+            assert.strictEqual(expanded, false);
+        });
+    });
+
+    test('keeps aggregate descendants to names and types without scalar metadata', async () => {
+        const expandedReferences: number[] = [];
+        const executor = {
+            hasActiveSession: async () => true,
+            getVariables: async () => ({
+                scopes: [{
+                    name: 'Local variables',
+                    variables: [{
+                        name: 'probe_record',
+                        value: '{:label=>"rbilling", :count=>41}',
+                        type: 'Hash',
+                        variablesReference: 20,
+                        namedVariables: 3
+                    }]
+                }]
+            }),
+            getVariableChildren: async (reference: number, options: any) => {
+                expandedReferences.push(reference);
+                assert.deepStrictEqual(options, { indexedVariables: undefined });
+                return [{
+                    name: '#class',
+                    value: 'Hash',
+                    type: 'Class',
+                    variablesReference: 23
+                }, {
+                    name: ':label',
+                    value: '"rbilling"',
+                    type: 'String',
+                    variablesReference: 21
+                }, {
+                    name: ':count',
+                    value: '41',
+                    type: 'Integer',
+                    variablesReference: 22
+                }];
+            }
+        } as unknown as IDebuggingExecutor;
+
+        await withActiveFrame(async () => {
+            const output = await new DebuggingHandler(executor, {} as any, 30)
+                .handleGetVariables({ variableNames: ['probe_record'], scope: 'local' });
+
+            assert.match(output, /probe_record \(Hash\)/);
+            assert.match(output, /:label \(String\)/);
+            assert.match(output, /:count \(Integer\)/);
+            assert.doesNotMatch(output, /rbilling|:count=>41|#class/);
+            assert.deepStrictEqual(expandedReferences, [20]);
+        });
+    });
+
+    test('uses indexed DAP paging for Ruby Array children', async () => {
+        const requests: Array<{ command: string; args: any }> = [];
+        const descriptor = Object.getOwnPropertyDescriptor(vscode.debug, 'activeDebugSession');
+        Object.defineProperty(vscode.debug, 'activeDebugSession', {
+            configurable: true,
+            get: () => ({
+                id: 'ruby-session',
+                name: 'Ruby LSP',
+                type: 'ruby_lsp',
+                customRequest: async (command: string, args: any) => {
+                    requests.push({ command, args });
+                    return { variables: [] };
+                }
+            })
+        });
+
+        try {
+            await new DebuggingExecutor().getVariableChildren(50, {
+                indexedVariables: 2
+            });
+
+            assert.deepStrictEqual(requests, [{
+                command: 'variables',
+                args: {
+                    variablesReference: 50,
+                    filter: 'indexed',
+                    start: 0,
+                    count: 2
+                }
+            }]);
+        } finally {
+            if (descriptor) {
+                Object.defineProperty(vscode.debug, 'activeDebugSession', descriptor);
+            }
+        }
+    });
+
+    test('returns scalar expression results instead of expanding rdbg metadata', async () => {
+        let expanded = false;
+        const executor = {
+            hasActiveSession: async () => true,
+            evaluateExpression: async () => ({
+                result: '42',
+                type: 'Integer',
+                variablesReference: 30
+            }),
+            getVariableChildren: async () => {
+                expanded = true;
+                return [{ name: '#class', type: 'Class', variablesReference: 31 }];
+            }
+        } as unknown as IDebuggingExecutor;
+
+        await withActiveFrame(async () => {
+            const output = await new DebuggingHandler(executor, {} as any, 30)
+                .handleEvaluateExpression({ expression: 'probe_value + 1' });
+
+            assert.match(output, /Result: 42 \(Integer\)/);
+            assert.doesNotMatch(output, /#class/);
+            assert.strictEqual(expanded, false);
+        });
+    });
+
+    test('still redacts Ruby String values that have metadata children', async () => {
+        const executor = {
+            hasActiveSession: async () => true,
+            getVariables: async () => ({
+                scopes: [{
+                    name: 'Local variables',
+                    variables: [{
+                        name: 'api_token',
+                        value: '"ghp_abcdefghijklmnopqrstuvwxyz0123456789"',
+                        type: 'String',
+                        variablesReference: 40
+                    }]
+                }]
+            }),
+            getVariableChildren: async () => {
+                throw new Error('Ruby String metadata should not be expanded');
+            }
+        } as unknown as IDebuggingExecutor;
+
+        await withActiveFrame(async () => {
+            const output = await new DebuggingHandler(executor, {} as any, 30)
+                .handleGetVariables({ variableNames: ['api_token'], scope: 'local' });
+
+            assert.doesNotMatch(output, /ghp_/);
+            assert.match(output, /<redacted: possible secret>/);
+        });
+    });
+});

--- a/src/test/startDebuggingMatrix.test.ts
+++ b/src/test/startDebuggingMatrix.test.ts
@@ -119,7 +119,8 @@ const LANGUAGES: LangCase[] = [
     { label: 'Java',       file: '/repo/src/App.java',        debuggerType: 'java'     },
     { label: 'C#',         file: '/repo/src/AppTests.cs',     debuggerType: 'coreclr'  },
     { label: 'C++',        file: '/repo/src/app.cpp',         debuggerType: 'cppdbg'   },
-    { label: 'Go',         file: '/repo/src/main.go',         debuggerType: 'go'       }
+    { label: 'Go',         file: '/repo/src/main.go',         debuggerType: 'go'       },
+    { label: 'Ruby',       file: '/repo/src/app.rb',          debuggerType: 'ruby_lsp' }
 ];
 
 suite('handleStartDebugging regression matrix', () => {
@@ -308,6 +309,47 @@ suite('handleStartDebugging regression matrix', () => {
 
         const result = await pending;
         assert.match(result, /stopped at breakpoint/);
+    });
+
+    test('[Ruby] test path continues past the rdbg entry pause to the configured breakpoint', async () => {
+        const entryState = new DebugState();
+        entryState.sessionActive = true;
+        entryState.fileName = 'example_spec.rb';
+        entryState.currentLine = 5;
+        entryState.breakpoints = ['example_spec.rb:12'];
+
+        const breakpointState = entryState.clone();
+        breakpointState.currentLine = 12;
+
+        const runComplete = deferred<void>();
+        const { executor, configManager } = makeMocks({
+            testDispatch: { started: true, runComplete: runComplete.promise },
+            language: 'ruby_lsp'
+        });
+        let readinessChecks = 0;
+        let stateReads = 0;
+        let continueCalls = 0;
+        executor.waitForDebugSessionReady = async () => {
+            readinessChecks++;
+            return 'stopped';
+        };
+        executor.getCurrentDebugState = async () =>
+            stateReads++ === 0 ? entryState : breakpointState;
+        executor.getActiveSession = () => ({ type: 'ruby_lsp' }) as vscode.DebugSession;
+        executor.continue = async () => {
+            continueCalls++;
+        };
+
+        const result = await new DebuggingHandler(executor, configManager, 30).handleStartDebugging({
+            fileFullPath: '/repo/example_spec.rb',
+            workingDirectory: '/repo',
+            testName: 'returns the result'
+        });
+
+        assert.match(result, /"currentLine": 12/);
+        assert.strictEqual(continueCalls, 1);
+        assert.strictEqual(readinessChecks, 2);
+        runComplete.resolve();
     });
 });
 

--- a/src/utils/debugConfigurationManager.ts
+++ b/src/utils/debugConfigurationManager.ts
@@ -48,7 +48,7 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
         '.go': 'go',
         '.rs': 'lldb',
         '.php': 'php',
-        '.rb': 'ruby'
+        '.rb': 'ruby_lsp'
     };
 
     /**
@@ -73,6 +73,19 @@ export class DebugConfigurationManager implements IDebugConfigurationManager {
         // .NET needs the compiled assembly, not the .cs source file.
         if (language === 'coreclr') {
             return await this.createDotNetLaunchConfig(fileFullPath);
+        }
+
+        // Ruby LSP accepts a command and file separately, then quotes the file
+        // when it builds the rdbg command. Keeping them separate avoids broken
+        // launches for paths containing spaces or shell metacharacters.
+        if (language === 'ruby_lsp') {
+            return {
+                type: language,
+                request: 'launch',
+                name: 'DebugMCP Launch',
+                command: 'ruby',
+                file: fileFullPath
+            };
         }
 
         // Minimal stub. The language extension's resolveDebugConfiguration


### PR DESCRIPTION
## Summary

- add Ruby LSP launch configuration support
- handle Ruby debugger entry pauses and variable inspection
- add Ruby coverage to the debugging regression matrix and architecture documentation

## Validation

- `npm run compile`
- `npm run lint`
- `npm test` (168 passing)