### PR TITLE
Support breakpoints in virtual source documents such as AL .dal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DebugMCP will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- Breakpoint, logpoint, and removal tools now support VS Code virtual-document URIs, including Business Central `al-preview:` `.dal` sources. An optional `workingDirectory` selects the correct workspace when multiple editor windows are open.
+
 ## [2.3.0] - 2026-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ DebugMCP is an MCP server that gives AI coding agents full control over the VS C
 | **continue_execution** | Continue until next breakpoint | None |
 | **pause_execution** | Interrupt a freely-running program and stop at its current location (no breakpoint needed) | None |
 | **restart_debugging** | Restart the current debug session | None |
-| **add_breakpoint** | Add a breakpoint at a specific line (optionally conditional) | `fileFullPath` (required)<br>`line` (required, 1-based)<br>`condition` (optional) |
-| **add_logpoint** | Add a logpoint that logs a message (instead of pausing) when a line is reached | `fileFullPath` (required)<br>`line` (required, 1-based)<br>`logMessage` (required, `{expr}` interpolated)<br>`condition` (optional) |
-| **remove_breakpoint** | Remove a breakpoint from a specific line | `fileFullPath` (required)<br>`line` (required) |
+| **add_breakpoint** | Add a breakpoint at a specific line (optionally conditional) | `fileFullPath` (required; path or virtual URI)<br>`workingDirectory` (optional; identifies the window for virtual URIs)<br>`line` (required, 1-based)<br>`condition` (optional) |
+| **add_logpoint** | Add a logpoint that logs a message (instead of pausing) when a line is reached | `fileFullPath` (required; path or virtual URI)<br>`workingDirectory` (optional; identifies the window for virtual URIs)<br>`line` (required, 1-based)<br>`logMessage` (required, `{expr}` interpolated)<br>`condition` (optional) |
+| **remove_breakpoint** | Remove a breakpoint from a specific line | `fileFullPath` (required; path or virtual URI)<br>`workingDirectory` (optional; identifies the window for virtual URIs)<br>`line` (required) |
 | **clear_all_breakpoints** | Remove all breakpoints at once | None |
 | **list_breakpoints** | List all active breakpoints | None |
 | **list_variable_names** | List names and types of variables in scope, without reading any values | `scope` (optional: 'local', 'global', 'all') |
@@ -156,6 +156,16 @@ DebugMCP supports debugging for the following languages with their respective VS
 | **PHP** | [PHP Debug](https://marketplace.visualstudio.com/items?itemName=xdebug.php-debug) | `.php` | ✅ Fully Supported |
 | **Ruby** | [Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.ruby) | `.rb` | ✅ Fully Supported |
 | **C#/.NET** | [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) | `.cs`, `.csproj` | ✅ Fully Supported |
+| **AL (Business Central)** | [AL Language](https://marketplace.visualstudio.com/items?itemName=ms-dynamics-smb.al) | `.al`, virtual `.dal` | ✅ Supported with an AL launch configuration |
+
+### Virtual source documents
+
+Breakpoint tools accept native filesystem paths and VS Code virtual-document URIs. This
+supports generated or downloaded sources that a language extension exposes without a local
+file, including Business Central dependency objects such as
+`al-preview://AlLang/.../Table/18/Customer.dal`. When multiple editor windows are open,
+pass `workingDirectory` with the virtual URI so DebugMCP routes the operation to the correct
+workspace.
 
 ## Configuration
 

--- a/docs/architecture/debugMCPServer.md
+++ b/docs/architecture/debugMCPServer.md
@@ -50,6 +50,8 @@ extension. To avoid debugging the wrong workspace when several windows are open:
   operation to that window's `ControlServer`. The target is cached per session so hint-less
   follow-ups (step/continue/inspect) reach the same window. If the router window closes,
   a worker window takes over the port on retry.
+- Breakpoint tools also accept virtual source URIs. A sole registered window is unambiguous;
+  with multiple windows, callers provide the optional `workingDirectory` routing hint.
 
 `DebugMCPServer` builds one handler **per MCP session** via a handler factory, which is
 what lets concurrent agent sessions drive debuggers in different repos simultaneously.
@@ -117,7 +119,7 @@ error wins:
 | `continue_execution` | Continue to next breakpoint |
 | `pause_execution` | Interrupt a running program (no breakpoint needed) |
 | `restart_debugging` | Restart session |
-| `add/remove_breakpoint` | Breakpoint management |
+| `add/remove_breakpoint` | Breakpoint management for local paths and virtual source URIs |
 | `clear_all_breakpoints` | Remove all breakpoints |
 | `list_breakpoints` | List active breakpoints |
 | `get_variables_values` | Read the values of specifically named variables |

--- a/docs/architecture/debuggingHandler.md
+++ b/docs/architecture/debuggingHandler.md
@@ -11,6 +11,7 @@ Debugging is inherently asynchronous - when you step over a line, the debugger t
 ## Responsibility
 
 - Orchestrate debugging operations (start, stop, step, breakpoints)
+- Preserve language-extension virtual source URIs when opening documents and setting breakpoints
 - Detect when debugger state has meaningfully changed after commands
 - Format debug state into human/AI-readable responses
 - Recursively format explicitly requested structs and arrays
@@ -58,6 +59,13 @@ A state change is considered meaningful when any of these change:
 - Current line number
 - Frame name (function/method)
 - Frame ID
+
+### Virtual source documents
+
+Breakpoint and logpoint locations may be native paths or VS Code virtual-document URIs.
+`src/utils/sourceUri.ts` keeps custom schemes intact instead of converting them into malformed
+`file:` URIs. This is required for language-extension sources such as Business Central `.dal`
+documents served through the `al-preview:` scheme.
 
 ### Root Cause Analysis
 

--- a/src/debugMCPServer.ts
+++ b/src/debugMCPServer.ts
@@ -263,33 +263,36 @@ export class DebugMCPServer {
         server.registerTool('add_breakpoint', {
             description: 'Set a breakpoint to pause execution at a critical line of code. Breakpoints let you inspect variables and control flow at exact moments.',
             inputSchema: {
-                fileFullPath: z.string().describe('Full path to the file'),
+                fileFullPath: z.string().describe('Full path or VS Code virtual-document URI of the source file'),
+                workingDirectory: z.string().optional().describe('Workspace directory used to select the correct VS Code window. Required for a virtual-document URI when multiple windows are open.'),
                 line: z.number().int().describe('Line number (1-based) where the breakpoint should be set'),
                 condition: z.string().optional().describe('Optional condition expression. When provided, execution only pauses if this expression evaluates to true at the breakpoint location.'),
             },
-        }, async (args: { fileFullPath: string; line: number; condition?: string }) =>
+        }, async (args: { fileFullPath: string; workingDirectory?: string; line: number; condition?: string }) =>
             this.runTool('add_breakpoint', () => debuggingHandler.handleAddBreakpoint(args)));
 
         // Add logpoint tool
         server.registerTool('add_logpoint', {
             description: 'Add a logpoint: a breakpoint that logs a message instead of pausing execution. Ideal for tracing values across many iterations or hot paths without stopping, or where a hard pause would distort timing. Embed expressions in curly braces to interpolate runtime values, e.g. "user id={user.id}".',
             inputSchema: {
-                fileFullPath: z.string().describe('Full path to the file'),
+                fileFullPath: z.string().describe('Full path or VS Code virtual-document URI of the source file'),
+                workingDirectory: z.string().optional().describe('Workspace directory used to select the correct VS Code window. Required for a virtual-document URI when multiple windows are open.'),
                 line: z.number().int().describe('Line number (1-based) where the logpoint should be set'),
                 logMessage: z.string().describe('Message to log when the line is reached. Wrap expressions in {curly braces} to interpolate runtime values.'),
                 condition: z.string().optional().describe('Optional condition expression. When provided, the message is only logged if this expression evaluates to true.'),
             },
-        }, async (args: { fileFullPath: string; line: number; logMessage: string; condition?: string }) =>
+        }, async (args: { fileFullPath: string; workingDirectory?: string; line: number; logMessage: string; condition?: string }) =>
             this.runTool('add_logpoint', () => debuggingHandler.handleAddLogpoint(args)));
 
         // Remove breakpoint tool
         server.registerTool('remove_breakpoint', {
             description: 'Remove a breakpoint that is no longer needed.',
             inputSchema: {
-                fileFullPath: z.string().describe('Full path to the file'),
+                fileFullPath: z.string().describe('Full path or VS Code virtual-document URI of the source file'),
+                workingDirectory: z.string().optional().describe('Workspace directory used to select the correct VS Code window. Required for a virtual-document URI when multiple windows are open.'),
                 line: z.number().describe('Line number (1-based)'),
             },
-        }, async (args: { fileFullPath: string; line: number }) =>
+        }, async (args: { fileFullPath: string; workingDirectory?: string; line: number }) =>
             this.runTool('remove_breakpoint', () => debuggingHandler.handleRemoveBreakpoint(args)));
 
         // Clear all breakpoints tool

--- a/src/debuggingHandler.ts
+++ b/src/debuggingHandler.ts
@@ -5,6 +5,7 @@ import { DebugConfigurationManager, IDebugConfigurationManager } from './utils/d
 import { DebugState } from './debugState';
 import { IDebuggingExecutor } from './debuggingExecutor';
 import { logger } from './utils/logger';
+import { toSourceUri } from './utils/sourceUri';
 import {
     isSensitiveExpression,
     isSensitiveName,
@@ -26,9 +27,9 @@ export interface IDebuggingHandler {
     handleContinue(): Promise<string>;
     handlePause(): Promise<string>;
     handleRestart(): Promise<string>;
-    handleAddBreakpoint(args: { fileFullPath: string; line: number; condition?: string }): Promise<string>;
-    handleAddLogpoint(args: { fileFullPath: string; line: number; logMessage: string; condition?: string }): Promise<string>;
-    handleRemoveBreakpoint(args: { fileFullPath: string; line: number }): Promise<string>;
+    handleAddBreakpoint(args: { fileFullPath: string; workingDirectory?: string; line: number; condition?: string }): Promise<string>;
+    handleAddLogpoint(args: { fileFullPath: string; workingDirectory?: string; line: number; logMessage: string; condition?: string }): Promise<string>;
+    handleRemoveBreakpoint(args: { fileFullPath: string; workingDirectory?: string; line: number }): Promise<string>;
     handleClearAllBreakpoints(): Promise<string>;
     handleListBreakpoints(): Promise<string>;
     handleGetVariables(args: { variableNames: string[]; scope?: 'local' | 'global' | 'all' }): Promise<string>;
@@ -310,7 +311,7 @@ export class DebuggingHandler implements IDebuggingHandler {
      * Add a breakpoint at specified location. An optional condition makes it a
      * conditional breakpoint that only pauses when the expression is true.
      */
-    public async handleAddBreakpoint(args: { fileFullPath: string; line: number; condition?: string }): Promise<string> {
+    public async handleAddBreakpoint(args: { fileFullPath: string; workingDirectory?: string; line: number; condition?: string }): Promise<string> {
         const { fileFullPath, line, condition } = args;
 
         try {
@@ -320,12 +321,12 @@ export class DebuggingHandler implements IDebuggingHandler {
 
             // Validate the line exists so we fail clearly instead of setting an
             // unbound breakpoint past the end of the file.
-            const document = await vscode.workspace.openTextDocument(vscode.Uri.file(fileFullPath));
+            const uri = toSourceUri(fileFullPath);
+            const document = await vscode.workspace.openTextDocument(uri);
             if (line > document.lineCount) {
                 throw new Error(`Line ${line} is out of range: ${fileFullPath} has ${document.lineCount} lines.`);
             }
 
-            const uri = vscode.Uri.file(fileFullPath);
             await this.executor.addBreakpoint(uri, line, condition);
 
             const conditionInfo = condition ? ` (condition: ${condition})` : '';
@@ -340,7 +341,7 @@ export class DebuggingHandler implements IDebuggingHandler {
      * interpolated by the debug adapter) instead of pausing execution. An
      * optional condition only logs when the expression is true.
      */
-    public async handleAddLogpoint(args: { fileFullPath: string; line: number; logMessage: string; condition?: string }): Promise<string> {
+    public async handleAddLogpoint(args: { fileFullPath: string; workingDirectory?: string; line: number; logMessage: string; condition?: string }): Promise<string> {
         const { fileFullPath, line, logMessage, condition } = args;
 
         try {
@@ -353,12 +354,12 @@ export class DebuggingHandler implements IDebuggingHandler {
 
             // Validate the line exists so we fail clearly instead of setting an
             // unbound logpoint past the end of the file.
-            const document = await vscode.workspace.openTextDocument(vscode.Uri.file(fileFullPath));
+            const uri = toSourceUri(fileFullPath);
+            const document = await vscode.workspace.openTextDocument(uri);
             if (line > document.lineCount) {
                 throw new Error(`Line ${line} is out of range: ${fileFullPath} has ${document.lineCount} lines.`);
             }
 
-            const uri = vscode.Uri.file(fileFullPath);
             await this.executor.addBreakpoint(uri, line, condition, logMessage);
 
             const conditionInfo = condition ? ` (condition: ${condition})` : '';
@@ -371,11 +372,11 @@ export class DebuggingHandler implements IDebuggingHandler {
     /**
      * Remove a breakpoint from specified location
      */
-    public async handleRemoveBreakpoint(args: { fileFullPath: string; line: number }): Promise<string> {
+    public async handleRemoveBreakpoint(args: { fileFullPath: string; workingDirectory?: string; line: number }): Promise<string> {
         const { fileFullPath, line } = args;
         
         try {
-            const uri = vscode.Uri.file(fileFullPath);
+            const uri = toSourceUri(fileFullPath);
             
             // Check if breakpoint exists at this location
             const breakpoints = this.executor.getBreakpoints();

--- a/src/routingDebuggingHandler.ts
+++ b/src/routingDebuggingHandler.ts
@@ -4,6 +4,7 @@ import * as http from 'http';
 import { IDebuggingHandler } from './debuggingHandler';
 import { WorkspaceRegistry, WindowRegistration } from './utils/workspaceRegistry';
 import { logger } from './utils/logger';
+import { isSourceUri } from './utils/sourceUri';
 
 /**
  * Router-window handler (one instance per MCP session) that forwards every
@@ -35,9 +36,15 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 	 * Resolve (and cache) the target from an optional path hint; a hint always
 	 * re-resolves, otherwise the cached target is reused.
 	 */
-	private resolveTarget(pathHint?: string): WindowRegistration {
+	private resolveTarget(pathHint?: string, virtualSource = false): WindowRegistration {
 		if (pathHint) {
-			const found = this.registry.findByPath(pathHint);
+			let found = virtualSource ? undefined : this.registry.findByPath(pathHint);
+			if (!found && virtualSource && !this.target) {
+				const windows = this.registry.list();
+				if (windows.length === 1) {
+					found = windows[0];
+				}
+			}
 			const candidates = this.registry
 				.list()
 				.map((w) => `pid=${w.pid} port=${w.controlPort} folders=[${w.workspaceFolders.join(', ') || 'none'}]`)
@@ -51,17 +58,26 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 			}
 		}
 		if (!this.target) {
-			throw new Error(this.noTargetMessage(pathHint));
+			throw new Error(this.noTargetMessage(pathHint, virtualSource));
 		}
 		return this.target;
 	}
 
-	private noTargetMessage(pathHint?: string): string {
+	private noTargetMessage(pathHint?: string, virtualSource = false): string {
 		const windows = this.registry.list();
 		const openList = windows
 			.map((w) => (w.workspaceFolders.length ? w.workspaceFolders.join(', ') : '(no folder)'))
 			.join('; ');
 		if (pathHint) {
+			if (virtualSource) {
+				return (
+					`DebugMCP could not select a VS Code window for virtual source URI "${pathHint}". ` +
+					'Pass workingDirectory to identify the workspace that owns the debug session. ' +
+					(openList
+						? `Currently registered workspaces: ${openList}.`
+						: 'No DebugMCP-enabled VS Code windows are currently registered.')
+				);
+			}
 			return (
 				`DebugMCP could not find an open VS Code window whose workspace contains "${pathHint}". ` +
 				(openList
@@ -75,8 +91,8 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 		);
 	}
 
-	private async forward(op: string, args: unknown, pathHint?: string): Promise<string> {
-		const target = this.resolveTarget(pathHint);
+	private async forward(op: string, args: unknown, pathHint?: string, virtualSource = false): Promise<string> {
+		const target = this.resolveTarget(pathHint, virtualSource);
 		try {
 			return await this.post(target, op, args);
 		} catch (error) {
@@ -200,16 +216,19 @@ export class RoutingDebuggingHandler implements IDebuggingHandler {
 		return this.forward('handleRestart', {});
 	}
 
-	public handleAddBreakpoint(args: { fileFullPath: string; line: number; condition?: string }): Promise<string> {
-		return this.forward('handleAddBreakpoint', args, args.fileFullPath);
+	public handleAddBreakpoint(args: { fileFullPath: string; workingDirectory?: string; line: number; condition?: string }): Promise<string> {
+		const virtualSource = !args.workingDirectory && isSourceUri(args.fileFullPath);
+		return this.forward('handleAddBreakpoint', args, args.workingDirectory || args.fileFullPath, virtualSource);
 	}
 
-	public handleAddLogpoint(args: { fileFullPath: string; line: number; logMessage: string; condition?: string }): Promise<string> {
-		return this.forward('handleAddLogpoint', args, args.fileFullPath);
+	public handleAddLogpoint(args: { fileFullPath: string; workingDirectory?: string; line: number; logMessage: string; condition?: string }): Promise<string> {
+		const virtualSource = !args.workingDirectory && isSourceUri(args.fileFullPath);
+		return this.forward('handleAddLogpoint', args, args.workingDirectory || args.fileFullPath, virtualSource);
 	}
 
-	public handleRemoveBreakpoint(args: { fileFullPath: string; line: number }): Promise<string> {
-		return this.forward('handleRemoveBreakpoint', args, args.fileFullPath);
+	public handleRemoveBreakpoint(args: { fileFullPath: string; workingDirectory?: string; line: number }): Promise<string> {
+		const virtualSource = !args.workingDirectory && isSourceUri(args.fileFullPath);
+		return this.forward('handleRemoveBreakpoint', args, args.workingDirectory || args.fileFullPath, virtualSource);
 	}
 
 	public handleClearAllBreakpoints(): Promise<string> {

--- a/src/test/debuggingHandler.test.ts
+++ b/src/test/debuggingHandler.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 
 import * as assert from 'assert';
+import * as vscode from 'vscode';
 import { DebugState } from '../debugState';
 import { DebuggingHandler } from '../debuggingHandler';
 import { IDebuggingExecutor } from '../debuggingExecutor';
@@ -204,4 +205,52 @@ suite('DebuggingHandler waitForStateChange (event-driven)', () => {
         assert.ok(elapsed >= 200, `should wait for the ~300ms timeout, only took ${elapsed}ms`);
         assert.ok(elapsed < 3000, `timeout should bound the wait, took ${elapsed}ms`);
     });
+});
+
+suite('DebuggingHandler virtual source breakpoints', () => {
+	test('passes an AL-style virtual .dal URI to the debug executor unchanged', async () => {
+		const scheme = `al-preview-test-${Date.now()}`;
+		const source = `${scheme}://AlLang/437dbf0e84ff417a965ded2bb9650972/Table/18/Customer.dal`;
+		let breakpointUri: vscode.Uri | undefined;
+		const provider = vscode.workspace.registerTextDocumentContentProvider(scheme, {
+			provideTextDocumentContent: () => 'table 18 Customer\n{\n}'
+		});
+		const executor: IDebuggingExecutor = {
+			startDebugging: async () => true,
+			debugTestAtCursor: async () => ({ started: true, runComplete: Promise.resolve() }),
+			stopDebugging: async () => { /* noop */ },
+			stepOver: async () => { /* noop */ },
+			stepInto: async () => { /* noop */ },
+			stepOut: async () => { /* noop */ },
+			continue: async () => { /* noop */ },
+			pause: async () => { /* noop */ },
+			restart: async () => { /* noop */ },
+			addBreakpoint: async (uri) => { breakpointUri = uri; },
+			removeBreakpoint: async () => { /* noop */ },
+			getCurrentDebugState: async () => new DebugState(),
+			getVariables: async () => ({}),
+			getVariableChildren: async () => [],
+			evaluateExpression: async () => ({}),
+			getBreakpoints: () => [],
+			clearAllBreakpoints: () => { /* noop */ },
+			hasActiveSession: async () => false,
+			getActiveSession: () => undefined,
+			waitForDebugSessionReady: async () => 'no-session'
+		};
+
+		try {
+			const handler = new DebuggingHandler(executor, {} as any, 30);
+			const result = await handler.handleAddBreakpoint({ fileFullPath: source, line: 2 });
+
+			assert.strictEqual(breakpointUri?.scheme, scheme);
+			assert.strictEqual(breakpointUri?.authority, 'AlLang');
+			assert.strictEqual(
+				breakpointUri?.path,
+				'/437dbf0e84ff417a965ded2bb9650972/Table/18/Customer.dal'
+			);
+			assert.match(result, /Breakpoint added/);
+		} finally {
+			provider.dispose();
+		}
+	});
 });

--- a/src/test/routing.test.ts
+++ b/src/test/routing.test.ts
@@ -146,6 +146,55 @@ suite('Multi-window routing', () => {
 		assert.strictEqual(handlerB.calls.length, 0);
 	});
 
+	test('virtual source breakpoint uses workingDirectory to select its window', async () => {
+		const repoA = path.join(dir, 'repoA');
+		const repoB = path.join(dir, 'repoB');
+		const handlerA = new RecordingHandler('A');
+		const handlerB = new RecordingHandler('B');
+		await startWindow('a.json', [repoA], handlerA);
+		await startWindow('b.json', [repoB], handlerB);
+
+		const routing = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
+		const result = await routing.handleAddBreakpoint({
+			fileFullPath: 'al-preview://AlLang/app/Table/18/Customer.dal',
+			workingDirectory: repoB,
+			line: 1
+		});
+
+		assert.strictEqual(result, 'B:addBp');
+		assert.strictEqual(handlerA.calls.length, 0);
+	});
+
+	test('virtual source breakpoint falls back to the sole registered window', async () => {
+		const repoA = path.join(dir, 'repoA');
+		const handlerA = new RecordingHandler('A');
+		await startWindow('a.json', [repoA], handlerA);
+
+		const routing = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
+		const result = await routing.handleAddBreakpoint({
+			fileFullPath: 'al-preview://AlLang/app/Table/18/Customer.dal',
+			line: 1
+		});
+
+		assert.strictEqual(result, 'A:addBp');
+	});
+
+	test('virtual source breakpoint requires workingDirectory when multiple windows are open', async () => {
+		const repoA = path.join(dir, 'repoA');
+		const repoB = path.join(dir, 'repoB');
+		await startWindow('a.json', [repoA], new RecordingHandler('A'));
+		await startWindow('b.json', [repoB], new RecordingHandler('B'));
+
+		const routing = new RoutingDebuggingHandler(new WorkspaceRegistry(process.pid, dir));
+		await assert.rejects(
+			() => routing.handleAddBreakpoint({
+				fileFullPath: 'al-preview://AlLang/app/Table/18/Customer.dal',
+				line: 1
+			}),
+			/Pass workingDirectory/
+		);
+	});
+
 	test('throws a helpful error when no window owns the path', async () => {
 		const repoA = path.join(dir, 'repoA');
 		const repoB = path.join(dir, 'repoB');
@@ -227,4 +276,3 @@ suite('Multi-window routing', () => {
 		);
 	});
 });
-

--- a/src/test/sourceUri.test.ts
+++ b/src/test/sourceUri.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { isSourceUri, toSourceUri } from '../utils/sourceUri';
+
+suite('Source URI handling', () => {
+	test('preserves an AL virtual .dal document URI', () => {
+		const source = 'al-preview://AlLang/437dbf0e84ff417a965ded2bb9650972/Table/18/Customer.dal';
+		const uri = toSourceUri(source);
+
+		assert.strictEqual(isSourceUri(source), true);
+		assert.strictEqual(uri.scheme, 'al-preview');
+		assert.strictEqual(uri.authority, 'AlLang');
+		assert.strictEqual(uri.path, '/437dbf0e84ff417a965ded2bb9650972/Table/18/Customer.dal');
+		assert.strictEqual(
+			uri.toString(),
+			'al-preview://allang/437dbf0e84ff417a965ded2bb9650972/Table/18/Customer.dal'
+		);
+	});
+
+	test('keeps native filesystem paths as file URIs', () => {
+		const source = path.join(path.sep, 'workspace', 'src', 'main.ts');
+		const uri = toSourceUri(source);
+
+		assert.strictEqual(isSourceUri(source), false);
+		assert.strictEqual(uri.scheme, 'file');
+		assert.strictEqual(uri.fsPath, source);
+	});
+
+	test('does not mistake a Windows drive letter for a URI scheme', () => {
+		assert.strictEqual(isSourceUri('C:\\workspace\\src\\main.ts'), false);
+	});
+});

--- a/src/utils/sourceUri.ts
+++ b/src/utils/sourceUri.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+
+import * as vscode from 'vscode';
+
+/**
+ * True when a source location is a URI rather than a native filesystem path.
+ *
+ * The drive letter in a Windows path looks like a URI scheme, so explicitly
+ * exclude drive-letter paths before applying the generic scheme check.
+ */
+export function isSourceUri(source: string): boolean {
+	if (/^[a-zA-Z]:[\\/]/.test(source)) {
+		return false;
+	}
+	return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(source);
+}
+
+/** Preserve virtual-document schemes while retaining native path behavior. */
+export function toSourceUri(source: string): vscode.Uri {
+	return isSourceUri(source) ? vscode.Uri.parse(source, true) : vscode.Uri.file(source);
+}


### PR DESCRIPTION
## Summary

- preserve virtual-document URIs when adding, removing, or logging breakpoints
- add an optional `workingDirectory` routing hint for virtual sources in multi-window sessions
- keep native POSIX and Windows file-path behavior unchanged
- document AL `.dal` breakpoint support and add focused routing/source URI tests

## Why

DebugMCP previously passed every source argument to `vscode.Uri.file()`. That rewrites an AL virtual source such as `al-preview://AlLang/.../Customer%20List.dal` into a local `file://` URI, so the Microsoft AL extension cannot resolve the document and the breakpoint cannot bind.

The new source URI helper preserves URI schemes while still treating Windows drive paths as files. The router can use `workingDirectory` to select the owning editor window; it can also reuse the active target or the sole registered window.

## Validation

- `npm run check-types`
- `npm run lint`
- `npm run bundle`
- full extension-host test suite: 160 passing in Antigravity IDE 1.107.0
- integration test loaded the installed Microsoft AL extension and resolved the real Base Application `Customer.dal` virtual source
- end-to-end Business Central Cloud debug in Antigravity with AL extension 18.0.2668733:
  - added a breakpoint to `al-preview://AlLang/437dbf0e84ff417a965ded2bb9650972/Page/22/Customer%20List.dal:1675`
  - debugger stopped in standard Page 22 `OnOpenPage`
  - listed globals and locals, including `Rec` as `Table Customer (18)`
  - stepped from line 1675 to 1676, then continued and stopped the session
  - removed all test breakpoints