### PR TITLE
Bump extension version to 2.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to DebugMCP will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.3.4] - 2026-09-03
+
+### Added
+- **`get_debug_status` tool** - reports whether the debuggee is paused, running, or inactive and can optionally wait for a breakpoint without changing execution state.
+
+### Changed
+- Debugger navigation now records clearer timing and location diagnostics, and hint-less operations can safely route to the sole registered VS Code window.
+- npm lockfiles no longer record registry-specific download URLs, improving portability across package registries.
+
+### Fixed
+- `start_debugging` now returns promptly after attaching to a long-lived process instead of waiting for a stop event that may never occur.
+- `continue_execution` now returns as soon as the debuggee resumes while step operations continue waiting for their next stack frame.
+- Fork pull requests no longer fail extension builds when the optional artifact-comment step lacks write permission.
+
+### Dependencies
+- Updated `@humanfs/node`, `@humanfs/core`, `fast-uri`, and `qs`.
+
 ## [2.3.0] - 2026-07-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Let AI agents debug your code inside VS Code - set breakpoints, step through exe
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![VS Code](https://img.shields.io/badge/VS%20Code-1.104.0+-blue.svg)](https://code.visualstudio.com/)
-[![Version](https://img.shields.io/badge/version-2.3.3-green.svg)](https://github.com/microsoft/DebugMCP)
+[![Version](https://img.shields.io/badge/version-2.3.4-green.svg)](https://github.com/microsoft/DebugMCP)
 [![VS Marketplace](https://img.shields.io/badge/VS%20Marketplace-Install-blue.svg)](https://marketplace.visualstudio.com/items?itemName=ozzafar.debugmcpextension)
 
 > ⭐ **If you find DebugMCP useful, please [star the repo on GitHub](https://github.com/microsoft/DebugMCP)!** It helps others discover the project and motivates continued development.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "debugmcpextension",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "debugmcpextension",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "debugmcpextension",
   "displayName": "DebugMCP — Agentic Debugging for VS Code, Cursor & More",
   "description": "Your AI agent debugs for you — right inside VS Code, Cursor & other VS Code-based editors. Let Copilot, Cline, Cursor, Codex & any MCP agent set breakpoints, step through code, and inspect variables live instead of guessing from logs.",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "publisher": "ozzafar",
   "author": {
     "name": "Oz Zafar",


### PR DESCRIPTION
## Summary

- bump the extension version from 2.3.3 to 2.3.4
- update package lock metadata and the README version badge
- add the 2.3.4 release notes to the changelog